### PR TITLE
Overlay improvements

### DIFF
--- a/Router/context.py
+++ b/Router/context.py
@@ -5,34 +5,36 @@ from pathlib import Path
 import tkinter as tk
 from tkinter import Widget as tkWidget
 from typing import Optional, TYPE_CHECKING
-from semantic_version import Version #type: ignore
+from semantic_version import Version  # type: ignore
 
 # to avoid circular imports, local imports go here
 if TYPE_CHECKING:
     from utils.updater import Updater
     from .route_manager import Router
+    from .overlay import Overlay
     from .ui import UI
     from .csv import CSV
 from .route import Route
 
+
 @dataclass
 class Context:
     # Plugin parameters
-    plugin_name:str = os.path.basename(os.path.dirname(__file__))
-    plugin_dir:Path = None
-    plugin_version:Version = None
-    plugin_useragent:str = None
+    plugin_name: str = os.path.basename(os.path.dirname(__file__))
+    plugin_dir: Path = None
+    plugin_version: Version = None
+    plugin_useragent: str = None
 
     # Config variables
-    parent:tkWidget = None
+    parent: tkWidget = None
 
     # Global variables
-    modules:list = field(default_factory=list) # Module details from Coriolis
+    modules: list = field(default_factory=list)  # Module details from Coriolis
 
     # Global objects
-    route:Route = Route([], [], 0, [])
-    router:'Router' = None
-    csv:'CSV' = None
-    ui:'UI' = None
-    updater:'Updater' = None
-
+    route: Route = Route([], [], 0, [])
+    router: "Router" = None
+    csv: "CSV" = None
+    ui: "UI" = None
+    updater: "Updater" = None
+    overlay: "Overlay" = None

--- a/Router/overlay.py
+++ b/Router/overlay.py
@@ -1,71 +1,76 @@
-import textwrap
-import copy
 import json
-import re
+import threading
 from dataclasses import dataclass, asdict
+from enum import Enum
 from functools import partial
 
 import tkinter as tk
 from tkinter import ttk, colorchooser as tkColorChooser
-import myNotebook as nb # type: ignore
+import myNotebook as nb  # type: ignore
 
 try:
-    from EDMCOverlay import edmcoverlay # type: ignore
-    from overlay_plugin.overlay_api import define_plugin_group as _define_plugin_group #type: ignore
+    from EDMCOverlay import edmcoverlay  # type: ignore
+    from overlay_plugin.overlay_api import define_plugin_group as _define_plugin_group  # type: ignore
 except ImportError:
     try:
-        from edmcoverlay import edmcoverlay # type: ignore
+        from edmcoverlay import edmcoverlay  # type: ignore
 
     except ImportError:
         edmcoverlay = None
 
-from config import config # type:ignore
+from config import config  # type:ignore
 
 from utils.debug import Debug, catch_exceptions
 from utils.placeholder import Placeholder
 from .context import Context
 from .constants import OVERLAY_NAME
 
+
+class OverlayMode(Enum):
+    cockpit = 1
+    galaxy_map = 2
+
+
 @dataclass
 class OvFrame:
-    """ Overlay frame details """
-    name:str = 'Default'
-    enabled:bool = True
-    x:int = 0
-    y:int = 0
-    w:int = 0
-    h:int = 0
-    centered_x:bool = False
-    centered_y:bool = False
-    ttl:int = 0
-    title_colour:str = 'white'
-    text_colour:str = 'white'
-    bgenabled:bool = False
-    background:str = 'grey'
-    border:str = ''
-    border_colour:str = ''
-    border_width:int = 0
-    anchor:str = "nw"
-    justification:str = "left" if centered_x == False else "center"
-    text_size:str = "normal"
+    """Overlay frame details"""
 
-class Overlay():
-    # Singleton pattern
-    _instance = None
+    name: str = "Default"
+    enabled: bool = True
+    cockpit_x: int = 525
+    cockpit_y: int = 625
+    galaxy_map_x: int = 460
+    galaxy_map_y: int = 70
+    x: int = 0
+    y: int = 0
+    w: int = 0
+    h: int = 0
+    centered_x: bool = False
+    centered_y: bool = False
+    ttl: int = 0
+    title_colour: str = "white"
+    text_colour: str = "white"
+    bgenabled: bool = False
+    background: str = "grey"
+    border: str = ""
+    border_colour: str = ""
+    border_width: int = 0
+    anchor: str = "nw"
+    justification: str = "left" if centered_x == False else "center"
+    text_size: str = "normal"
 
-    def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
 
+class Overlay:
 
     def __init__(self) -> None:
-        # Only initialize if it's the first time
-        if hasattr(self, '_initialized'): return
-        self.ovf:OvFrame = OvFrame()
-        overlay = self._get_overlay()
-
-        if overlay:
+        self._enabled: bool = None
+        self._thread: threading.Thread | None = None
+        self._stop = threading.Event()
+        self.mode: OverlayMode | None = None
+        self.title_text: str = ""
+        self.body_text: str = ""
+        self.ovf: OvFrame = OvFrame()
+        if self._overlay:
             _define_plugin_group(
                 plugin_group=OVERLAY_NAME,
                 matching_prefixes=[f"{OVERLAY_NAME}-"],
@@ -78,14 +83,22 @@ class Overlay():
                 background_border_width=2,
             )
         self._load_prefs()
+        self.enabled = self.ovf.enabled
 
-        self.src_msgs:dict = {}
-        self.msgs:dict = {}
-        self._initialized = True
+    @property
+    def enabled(self):
+        return self._enabled
 
+    @enabled.setter
+    def enabled(self, value):
+        if value is False and self._thread is not None:
+            # Stop the thread before we disable.
+            self.hide()
+        self._enabled = value
 
-    def _get_overlay(self):
-        """ Is an overlay installed and running? """
+    @property
+    def _overlay(self):
+        """Is an overlay installed and running?"""
         if not edmcoverlay:
             Debug.logger.warning(f"edmcoverlay plugin is not installed")
             return
@@ -97,61 +110,73 @@ class Overlay():
             Debug.logger.warning(f"EDMCOverlay is not running")
             return
 
-    def redraw_messages(self) -> None:
-        """ Clear all overlay messages """
-        Debug.logger.debug(f"Redrawing mesages")
-        [self.show_message(m, text) for m, text in self.src_msgs.items()]
-
-
-    def clear_messages(self) -> None:
-        """ Clear all overlay messages """
-        Debug.logger.debug(f"Clearing {self.msgs.keys()}")
-        [self.clear_message(m) for m in list(self.msgs)]
+    @catch_exceptions
+    def _draw_overlay(self) -> None:
+        x, y = {
+            OverlayMode.cockpit: (self.ovf.cockpit_x, self.ovf.cockpit_y),
+            OverlayMode.galaxy_map: (self.ovf.galaxy_map_x, self.ovf.galaxy_map_y),
+        }[self.mode]
+        # Draw title
+        self._overlay.send_message(
+            msgid=f"{OVERLAY_NAME}-{self.ovf.name}-title",
+            text=self.title_text,
+            color=self.ovf.text_colour,
+            x=x,
+            y=y,
+            ttl=1,
+            size="large",
+        )
+        # Draw body
+        self._overlay.send_message(
+            msgid=f"{OVERLAY_NAME}-{self.ovf.name}-body",
+            text=self.body_text,
+            color=self.ovf.text_colour,
+            x=x,
+            y=y + 20,
+            ttl=1,
+            size="normal",
+        )
 
     @catch_exceptions
-    def clear_message(self, msgid:str = "") -> bool:
-        """ Clear a message """
+    def show(self, mode: OverlayMode) -> None:
+        self.mode = mode
+        if not self._overlay or not self.enabled:
+            # No overlay, just no-op
+            return
+        if self._thread is not None:
+            # We're already started.
+            return
 
-        overlay = self._get_overlay()
-        if not overlay or msgid not in self.msgs: return False
+        def _loop():
+            while not self._stop.wait(1):
+                self._draw_overlay()
 
-        status:bool = self.ovf.enabled
-        self.ovf.enabled = True
-
-        msg:dict = self.msgs[msgid]
-        msg['ttl'] = 1
-        overlay.send_message(**msg)
-        del self.msgs[msgid]
-        self.ovf.enabled = status
-        return True
-
-
-    @catch_exceptions
-    def show_message(self, msgid:str = "", text:str|list = "", size:str = "normal", ttl=120) -> None:
-        overlay = self._get_overlay()
-        if not overlay or not self.ovf.enabled: return
-
-        if isinstance(text, str): text = [size, text]
-        y:int = self.ovf.y
-        for i in range(0, len(text), 2):
-            args:dict = {
-                'msgid': f"{OVERLAY_NAME}-{msgid}-{i}",
-                'text': text[i+1],
-                'color': self.ovf.text_colour,
-                'x': self.ovf.x,
-                'y': y,
-                'ttl': ttl,
-                'size': text[i]
-            }
-            Debug.logger.debug(f"Sending overlay message {args}")
-            overlay.send_message(**args)
-            self.msgs[f"{OVERLAY_NAME}-{msgid}-{i}"] = args
-            y += 20
-        self.src_msgs[msgid] = text
+        self._thread = threading.Thread(target=_loop, daemon=True)
+        # Draw the overlay immediately, then start the thread
+        self._draw_overlay()
+        self._thread.start()
 
     @catch_exceptions
-    def prefs_display(self, parent:nb.Frame) -> nb.Frame:
-        """ EDMC settings pane hook. Displays one frame per row. """
+    def hide(self) -> None:
+        if not self._overlay or not self.enabled:
+            # No overlay, just no-op
+            return
+        if self._thread is None:
+            # We're already stopped.
+            return
+        self._stop.set()
+        # Clear the message
+        self._overlay.send_raw({"id": f"{OVERLAY_NAME}-title", "text": "", "ttl": 0})
+        self._overlay.send_raw({"id": f"{OVERLAY_NAME}-body", "text": "", "ttl": 0})
+        # Wait for the thread to stop
+        self._thread.join()
+        # Clean up
+        self._thread = None
+        self._stop.clear()
+
+    @catch_exceptions
+    def prefs_display(self, parent: nb.Frame) -> nb.Frame:
+        """EDMC settings pane hook. Displays one frame per row."""
 
         def bind_var(data_obj, attribute, tk_var):
             # Update dataclass whenever the UI changes
@@ -161,7 +186,7 @@ class Overlay():
             tk_var.trace_add("write", update_obj)
             return tk_var
 
-        def colour_picker(parent:nb.Frame, which:str, col:tk.StringVar) -> None:
+        def colour_picker(parent: nb.Frame, which: str, col: tk.StringVar) -> None:
             (_, color) = tkColorChooser.askcolor(col.get(), title=which, parent=parent)
 
             if color:
@@ -170,66 +195,86 @@ class Overlay():
                 for b in cbtns:
                     b.config(**{which.lower(): color})
 
-        def validate_int(val:str) -> bool:
-            return True if val.isdigit() or val == '' else False
+        def validate_int(val: str) -> bool:
+            return True if val.isdigit() or val == "" else False
 
-        # Hide existing messages. Redraw them in the new location when the user clicks save
-        self.clear_messages()
-
-        prefsfr:nb.Frame = nb.Frame(parent)
+        prefsfr: nb.Frame = nb.Frame(parent)
         prefsfr.columnconfigure(6, weight=1)
         prefsfr.rowconfigure(60, weight=1)
         prefsfr.grid()
-        validate = (prefsfr.register(validate_int), '%P')
+        validate = (prefsfr.register(validate_int), "%P")
 
-        row:int = 0; col:int = 0
-        nb.Label(prefsfr, text="Overlay", justify=tk.LEFT).grid(row=row, column=0, padx=10, sticky=tk.NW); row += 1
+        row: int = 0
+        col: int = 0
+        nb.Label(prefsfr, text="Overlay", justify=tk.LEFT).grid(
+            row=row, column=0, padx=10, sticky=tk.NW
+        )
+        row += 1
 
-        vars:dict = {}; cbtns:list = []; col = 0
-        for k in [('enabled', 'Enable', tk.BooleanVar, tk.Checkbutton),
-                  ('x', 'X', tk.IntVar, tk.Entry),
-                  ('y', 'Y', tk.IntVar, tk.Entry),
-                  #('w', 'W', tk.IntVar, tk.Entry),
-                  #('h', 'H', tk.IntVar, tk.Entry),
-                  ('text_colour', 'Foreground', tk.StringVar, 'ColorPicker'),
-                  #('bgenabled', 'Use Background', tk.BooleanVar, tk.Checkbutton),
-                  #('background', 'Background', tk.StringVar, 'ColorPicker')
-                  ]:
+        vars: dict = {}
+        cbtns: list = []
+        col = 0
+        for k in [
+            ("enabled", "Enable", tk.BooleanVar, tk.Checkbutton),
+            ("cockpit_x", "Cockpit X", tk.IntVar, tk.Entry),
+            ("cockpit_y", "Cockpit Y", tk.IntVar, tk.Entry),
+            ("galaxy_map_x", "Galaxy Map X", tk.IntVar, tk.Entry),
+            ("galaxy_map_y", "Galaxy Map Y", tk.IntVar, tk.Entry),
+            # ('w', 'W', tk.IntVar, tk.Entry),
+            # ('h', 'H', tk.IntVar, tk.Entry),
+            ("text_colour", "Foreground", tk.StringVar, "ColorPicker"),
+            # ('bgenabled', 'Use Background', tk.BooleanVar, tk.Checkbutton),
+            # ('background', 'Background', tk.StringVar, 'ColorPicker')
+        ]:
 
             vars[k[0]] = bind_var(self.ovf, k[0], k[2](value=getattr(self.ovf, k[0])))
             match k[3]:
                 case tk.Checkbutton:
-                    nb.Checkbutton(prefsfr, text=k[1], variable=vars[k[0]]).grid(row=row, column=col, padx=10, pady=0, sticky=tk.W)
+                    nb.Checkbutton(prefsfr, text=k[1], variable=vars[k[0]]).grid(
+                        row=row, column=col, padx=10, pady=0, sticky=tk.W
+                    )
                 case tk.Entry:
-                    nb.Label(prefsfr, text=k[1]).grid(row=row, column=col, padx=5, pady=5, sticky=tk.W)
+                    nb.Label(prefsfr, text=k[1]).grid(
+                        row=row, column=col, padx=5, pady=5, sticky=tk.W
+                    )
                     col += 1
-                    tk.Entry(prefsfr, textvariable=vars[k[0]], width=8, validate='all', validatecommand=validate).grid(row=row, column=col, padx=5, pady=5, sticky=tk.W)
-                case 'ColorPicker':
-                    btn:tk.Button = tk.Button(prefsfr, text=k[1], foreground=self.ovf.text_colour, background=self.ovf.background, command=partial(colour_picker, prefsfr, k[1], vars[k[0]]))
+                    tk.Entry(
+                        prefsfr,
+                        textvariable=vars[k[0]],
+                        width=8,
+                        validate="all",
+                        validatecommand=validate,
+                    ).grid(row=row, column=col, padx=5, pady=5, sticky=tk.W)
+                case "ColorPicker":
+                    btn: tk.Button = tk.Button(
+                        prefsfr,
+                        text=k[1],
+                        foreground=self.ovf.text_colour,
+                        background=self.ovf.background,
+                        command=partial(colour_picker, prefsfr, k[1], vars[k[0]]),
+                    )
                     btn.grid(row=row, column=col, padx=5, pady=5, sticky=tk.W)
                     cbtns.append(btn)
             col += 1
 
         return prefsfr
 
-
     def save_prefs(self) -> bool:
-        """ Serialize and save the frames dictionary to EDMC config. """
+        """Serialize and save the frames dictionary to EDMC config."""
         # Store the serialized frames in the config
 
         config.set(f"{OVERLAY_NAME}_overlay", json.dumps(asdict(self.ovf)))
-        if self.ovf.enabled == True:
-            self.redraw_messages()
+        self.enabled = self.ovf.enabled
 
         Debug.logger.info(f"Saved {self.ovf} frames to EDMC config")
         return True
 
-
     def _load_prefs(self) -> None:
-        """ Read frame data from the EDMC config. """
+        """Read frame data from the EDMC config."""
 
         conf = config.get(f"{OVERLAY_NAME}_overlay")
         Debug.logger.debug(f"Loading config: {conf}")
-        if conf == None: return
-        data:dict = json.loads(conf)
+        if conf == None:
+            return
+        data: dict = json.loads(conf)
         self.ovf = OvFrame(**data)

--- a/Router/route.py
+++ b/Router/route.py
@@ -2,136 +2,172 @@ from time import time
 from utils.debug import Debug
 from .constants import HEADER_MAP, tts
 
+
 class Route:
     """
-        Class to store, maintain, and return current route information
+    Class to store, maintain, and return current route information
     """
-    def __init__(self, hdrs:list = [], cols:list = [], offset:int = 0, jumps:list = []) -> None:
-        self.hdrs:list = hdrs
-        self.route:list = cols
-        self.jumps:list = jumps
-        self.offset:int = offset
-        self.fleetcarrier:bool = False
 
-        if hdrs == [] or cols == []: return
+    def __init__(
+        self, hdrs: list = [], cols: list = [], offset: int = 0, jumps: list = []
+    ) -> None:
+        self.hdrs: list = hdrs
+        self.route: list = cols
+        self.jumps: list = jumps
+        self.offset: int = offset
+        self.fleetcarrier: bool = False
+
+        if hdrs == [] or cols == []:
+            return
 
         # Detect if this route appears to be a fleet carrier loadout (tritium column)
-        self.fleetcarrier = any('tritium' in h.lower() for h in hdrs)
+        self.fleetcarrier = any("tritium" in h.lower() for h in hdrs)
 
-        self.sc:int|None = self.colind()
-        self.jc:int|None = self.colind('Jumps')
-        self.dc:int|None = self.colind('Distance Remaining' if 'Distance remaining' in self.hdrs else 'Distance Rem')
+        self.sc: int | None = self.colind()
+        self.jc: int | None = self.colind("Jumps")
+        self.dc: int | None = self.colind(
+            "Distance Remaining"
+            if "Distance remaining" in self.hdrs
+            else "Distance Rem"
+        )
 
         # If necessary calculate jumps or waypoints remaining and insert into the headers & the route
-        if 'Jumps Rem' not in hdrs and 'Waypoints Rem' not in hdrs and self.fleetcarrier == False:
-            jr:int = len(hdrs)
-            if self.jc != None: jr = self.jc+1
+        if (
+            "Jumps Rem" not in hdrs
+            and "Waypoints Rem" not in hdrs
+            and self.fleetcarrier == False
+        ):
+            jr: int = len(hdrs)
+            if self.jc != None:
+                jr = self.jc + 1
 
-            self.hdrs.insert(jr, 'Jumps Rem' if self.jc != None else 'Waypoints Rem')
+            self.hdrs.insert(jr, "Jumps Rem" if self.jc != None else "Waypoints Rem")
             for i in range(0, len(cols)):
                 self.route[i].insert(jr, self.jumps_remaining(i))
 
             # Recalc, they may have moved.
-            self.sc:int|None = self.colind()
-            self.dc:int|None = self.colind('Distance Remaining' if 'Distance remaining' in self.hdrs else 'Distance Rem')
-
+            self.sc: int | None = self.colind()
+            self.dc: int | None = self.colind(
+                "Distance Remaining"
+                if "Distance remaining" in self.hdrs
+                else "Distance Rem"
+            )
 
     def source(self) -> str:
-        if self.route == []: return ''
+        if self.route == []:
+            return ""
         return self.route[0][self.sc]
 
-
     def destination(self) -> str:
-        if self.route == []: return ''
+        if self.route == []:
+            return ""
         return self.route[-1][self.sc]
 
-
-    def jumps_to_system(self, offset:int|None = None) -> int:
-        """ How many jumps to reach this system? """
-        if self.route == []: return -1
-        if offset == None: offset = self.offset
-        if offset >= len(self.route) or self.jc == None: return -1
+    def jumps_to_system(self, offset: int | None = None) -> int:
+        """How many jumps to reach this system?"""
+        if self.route == []:
+            return -1
+        if offset == None:
+            offset = self.offset
+        if offset >= len(self.route) or self.jc == None:
+            return -1
         return self.route[offset][self.jc]
 
-
     def next_stop(self) -> str:
-        """ Return system name or body name of the next waypoint """
-        if self.route == []: return ''
-        if self.offset >= len(self.route): return ''
+        """Return system name or body name of the next waypoint"""
+        if self.route == []:
+            return ""
+        if self.offset >= len(self.route):
+            return ""
         Debug.logger.debug(f"Next stop: {self.sc} {self.route[self.offset][self.sc]}")
         return self.route[self.offset][self.sc]
 
-
     def jumps_to_wp(self) -> int:
-        """ Return the number of jumps to the next waypoint """
-        if self.route == [] or self.jc == None: return 0
+        """Return the number of jumps to the next waypoint"""
+        if self.route == [] or self.jc == None:
+            return 0
         return self.route[self.offset][self.jc]
 
-
     def total_jumps(self) -> int:
-        """ Jumps remaining from start of route """
+        """Jumps remaining from start of route"""
         return self.jumps_remaining(0)
 
-
-    def jumps_remaining(self, offset:int|None = None) -> int:
-        """ Jumps remaining from this point. Either just rows left or sum of jumps column """
-        if self.route == []: return -1
-        if offset == None: offset = self.offset
-        if offset >= len(self.route)-1: return 0
+    def jumps_remaining(self, offset: int | None = None) -> int:
+        """Jumps remaining from this point. Either just rows left or sum of jumps column"""
+        if self.route == []:
+            return -1
+        if offset == None:
+            offset = self.offset
+        if offset >= len(self.route) - 1:
+            return 0
 
         # No jump count column
-        if self.jc == None: return len(self.route[offset:-1])
+        if self.jc == None:
+            return len(self.route[offset:-1])
 
-        syscol:int|None = self.colind('System Name')  # We want to use the system name rather than the body name to count jumps
-        if syscol == None: syscol = self.sc # Fallback to whatever column we use for the system if we don't have a system name column
-        return sum([j[self.jc] for i, j in enumerate(self.route[offset:]) if i == 0 or self.route[i-1][syscol] != j[syscol]])
+        syscol: int | None = self.colind(
+            "System Name"
+        )  # We want to use the system name rather than the body name to count jumps
+        if syscol == None:
+            syscol = (
+                self.sc
+            )  # Fallback to whatever column we use for the system if we don't have a system name column
+        return sum(
+            [
+                j[self.jc]
+                for i, j in enumerate(self.route[offset:])
+                if i == 0 or self.route[i - 1][syscol] != j[syscol]
+            ]
+        )
 
-
-    def perc_jumps_rem(self, offset:int|None = None) -> float:
-        """ Percentage of jumps remaining """
-        if self.route == []: return 0
+    def perc_jumps_rem(self, offset: int | None = None) -> float:
+        """Percentage of jumps remaining"""
+        if self.route == []:
+            return 0
         return (self.total_jumps() - self.jumps_remaining()) * 100 / self.total_jumps()
 
-
     def total_dist(self) -> int:
-        """ Total distance of the route """
+        """Total distance of the route"""
         return self.dist_remaining(0)
 
-
     def jumps_per_hour(self) -> float:
-        """ Jumps per hour on this route """
-        if self.jumps == []: return 0
-        td:float = (int(self.jumps[-1][0]) - int(self.jumps[0][0])) / 3600
+        """Jumps per hour on this route"""
+        if self.jumps == []:
+            return 0
+        td: float = (int(self.jumps[-1][0]) - int(self.jumps[0][0])) / 3600
         return len(self.jumps) / td if td > 0 else 0
 
-
     def dist_per_hour(self) -> float:
-        """ Ly per hour on this route """
-        if self.jumps == []: return 0
-        td:float = (int(self.jumps[-1][0]) - int(self.jumps[0][0])) / 3600
+        """Ly per hour on this route"""
+        if self.jumps == []:
+            return 0
+        td: float = (int(self.jumps[-1][0]) - int(self.jumps[0][0])) / 3600
         return sum([j[2] for j in self.jumps]) / td if td > 0 else 0
 
-
-    def dist_remaining(self, offset:int|None = None) -> int:
-        """ Distance remaining if we know it """
-        if self.route == [] or self.dc == None: return 0
-        if offset == None: offset = self.offset
+    def dist_remaining(self, offset: int | None = None) -> int:
+        """Distance remaining if we know it"""
+        if self.route == [] or self.dc == None:
+            return 0
+        if offset == None:
+            offset = self.offset
         return self.route[offset][self.dc]
 
+    def perc_dist_rem(self, offset: int | None = None) -> float:
+        """Percentage of distance remaining"""
+        if self.route == [] or self.total_dist() == 0:
+            return 0
+        return (
+            (self.total_dist() - self.dist_remaining(offset)) * 100 / self.total_dist()
+        )
 
-    def perc_dist_rem(self, offset:int|None = None) -> float:
-        """ Percentage of distance remaining """
-        if self.route == [] or self.total_dist() == 0: return 0
-        return (self.total_dist() - self.dist_remaining(offset)) * 100 / self.total_dist()
-
-
-    def colind(self, which:str = '') -> int|None:
-        """ Return the index of a given column, by default the system name column """
-        if self.hdrs == []: return None
+    def colind(self, which: str = "") -> int | None:
+        """Return the index of a given column, by default the system name column"""
+        if self.hdrs == []:
+            return None
 
         Debug.logger.debug(f"{self.hdrs}")
-        if which == '':
-            for h in ['Body Name', 'body', 'System Name', 'system', 'name']:
+        if which == "":
+            for h in ["Body Name", "body", "System Name", "system", "name"]:
                 if h in self.hdrs:
                     Debug.logger.debug(f"{h} {self.hdrs.index(h)}")
                     return self.hdrs.index(h)
@@ -145,29 +181,62 @@ class Route:
                 return self.hdrs.index(HEADER_MAP[w])
         return None
 
+    def get_waypoint(self, inc: int = 0) -> str:
+        """Return the system of a waypoint relative to our current offset"""
+        if (
+            self.route == []
+            or self.offset + inc > len(self.route) - 1
+            or self.offset + inc < 0
+        ):
+            return tts["none"]
 
-    def get_waypoint(self, inc:int = 0) -> str:
-        """ Return the system of a waypoint relative to our current offset """
-        if self.route == [] or self.offset + inc > len(self.route)-1 or self.offset+inc < 0: return tts["none"]
-
-        return self.route[self.offset+inc][self.sc]
-
+        return self.route[self.offset + inc][self.sc]
 
     def refuel(self) -> bool:
-        """ Return whether we need to refuel at this waypoint """
-        ind:int|None = self.colind('Refuel') or self.colind('Restock')
-        if ind == None: return False
-        return self.route[self.offset][ind] in [True, 'True', 'true', 'YES', 'Yes', 'yes', 1, '1']
+        """Return whether we need to refuel at this waypoint"""
+        ind: int | None = self.colind("Refuel") or self.colind("Restock")
+        if ind == None:
+            return False
+        return self.route[self.offset][ind] in [
+            True,
+            "True",
+            "true",
+            "YES",
+            "Yes",
+            "yes",
+            1,
+            "1",
+        ]
 
+    def next_refuel(self) -> int | None:
+        """
+        Returns how many jumps until the next fuel stop. Returns None if no fuel stops.
+        """
+        ind: int | None = self.colind("Refuel") or self.colind("Restock")
+        if ind == None:
+            return None
+        if self.offset > 0:
+            count = 0
+            waypoint_range = self.route[self.offset - 1 : len(self.route)]
+        else:
+            count = 1
+            waypoint_range = self.route[self.offset : len(self.route)]
+        for waypoint in waypoint_range:
+            if waypoint[ind] in [True, "True", "true", "YES", "Yes", "yes", 1, "1"]:
+                return count
+            count += 1
+        else:
+            return None
 
-    def update_route(self, direction:int = 0, system:str = '') -> int:
+    def update_route(self, direction: int = 0, system: str = "") -> int:
         """
         Step forwards or backwards through the route.
         If no direction is given pickup from wherever we are on the route
         """
-        if self.route == []: return -1
+        if self.route == []:
+            return -1
 
-        if direction == 0: # Figure out if we're on the route
+        if direction == 0:  # Figure out if we're on the route
             for i, r in enumerate(self.route):
                 if r[self.sc] == system:
                     self.offset = i
@@ -178,7 +247,9 @@ class Route:
                 Debug.logger.debug(f"We aren't on the route")
                 return -1
             direction = 1  # Default to moving forwards
-            Debug.logger.debug(f"New offset {self.offset} {direction} {self.route[self.offset][self.sc]}")
+            Debug.logger.debug(
+                f"New offset {self.offset} {direction} {self.route[self.offset][self.sc]}"
+            )
 
         # Are we at one end or the other?
         if self.offset + direction < 0:
@@ -190,21 +261,18 @@ class Route:
         self.offset += direction
         return self.offset
 
-
-    def record_jump(self, dest:str, dist:float) -> None:
-        """ Add details of an FSD jump """
+    def record_jump(self, dest: str, dist: float) -> None:
+        """Add details of an FSD jump"""
         Debug.logger.debug(f"Jump added")
         self.jumps.append([time(), dest, dist])
 
-
     def __repr__(self) -> str:
-        if self.route == []: return "No route"
+        if self.route == []:
+            return "No route"
         return f"{self.route[0][self.sc]} to {self.route[-1][self.sc]}"
-
 
     def __str__(self) -> str:
         return self.__repr__()
-
 
     def to_dict(self) -> list:
         return [self.hdrs, self.route, self.offset, self.jumps]

--- a/Router/route_manager.py
+++ b/Router/route_manager.py
@@ -1,28 +1,53 @@
 import json
 import re
 import requests
+import threading
+from datetime import datetime, timedelta
 from requests import Response
 from pathlib import Path
 from time import time, sleep
 from threading import Thread
 
-from config import config # type: ignore
+from config import config  # type: ignore
 from utils.debug import Debug, catch_exceptions
+from utils.misc import timedelta_str
 
-from .constants import lbls, errs, HEADERS, HEADER_MAP, DATA_DIR, SPANSH_ROUTE, SPANSH_GALAXY_ROUTE, SPANSH_RESULTS
+from .constants import (
+    lbls,
+    errs,
+    HEADERS,
+    HEADER_MAP,
+    DATA_DIR,
+    SPANSH_ROUTE,
+    SPANSH_GALAXY_ROUTE,
+    SPANSH_RESULTS,
+)
 from .context import Context
 from .ship import Ship
 from .route import Route
 
-SAVE_VARS:dict = {'system': '', 'src': '', 'dest': '', 'last_plot': 'Neutron',
-                  'carrier_id': '', 'carrier_state': 'Idle',
-                  'neutron_params': {}, 'galaxy_params': {},
-                  'ship_id': '', 'cargo': 0, 'shiplist': [], 'history': [],
-                  'window_geometries' : {}}
-class Router():
+SAVE_VARS: dict = {
+    "system": "",
+    "src": "",
+    "dest": "",
+    "last_plot": "Neutron",
+    "carrier_id": "",
+    "carrier_state": "Idle",
+    "neutron_params": {},
+    "galaxy_params": {},
+    "ship_id": "",
+    "cargo": 0,
+    "shiplist": [],
+    "history": [],
+    "window_geometries": {},
+}
+
+
+class Router:
     """
     Class to manage routes, all the route data and state information.
     """
+
     # Singleton pattern
     _instance = None
 
@@ -31,44 +56,47 @@ class Router():
             cls._instance = super().__new__(cls)
         return cls._instance
 
-
-    def __init__(self, test:bool = False) -> None:
+    def __init__(self, test: bool = False) -> None:
         # Only initialize if it's the first time
-        if hasattr(self, '_initialized'): return
+        if hasattr(self, "_initialized"):
+            return
 
         # Current location data and settings
-        self.system:str = ""
-        self.src:str = ''
-        self.dest:str = ''
+        self.system: str = ""
+        self.src: str = ""
+        self.dest: str = ""
 
         # Current ship data
-        self.ship_id:str = ""
-        self.cargo:int = 0
-        self.ship:Ship|None = None
+        self.ship_id: str = ""
+        self.cargo: int = 0
+        self.ship: Ship | None = None
 
         # Record of used ships and shipyard
-        self.shiplist:list = []
-        self.ships:dict[str, Ship] = {}
-        self.history:list = []
+        self.shiplist: list = []
+        self.ships: dict[str, Ship] = {}
+        self.history: list = []
 
         # Info about the last route plotted
-        self.last_plot:str = "Neutron"
-        self.galaxy_params:dict = {}
-        self.neutron_params:dict = {}
-        self.cancel_plot:bool = False
+        self.last_plot: str = "Neutron"
+        self.galaxy_params: dict = {}
+        self.neutron_params: dict = {}
+        self.cancel_plot: bool = False
 
         # Carrier
-        self.carrier_id:str = ''
-        self.carrier_state:str = 'Idle'
+        self.carrier_id: str = ""
+        self.carrier_state: str = "Idle"
+        self._carrier_jump_thread: threading.Thread | None = None
+        self._carrier_jump_thread_stop: threading.Event = threading.Event()
+        self._carrier_cooldown_thread: threading.Thread | None = None
+        self._carrier_cooldown_thread_stop: threading.Event = threading.Event()
 
-        self.window_geometries:dict = {}
+        self.window_geometries: dict = {}
 
         self._load()
 
         self._initialized = True
 
-
-    def swap_ship(self, ship_id:str) -> None:
+    def swap_ship(self, ship_id: str) -> None:
         """
         Called on a ship swap event to update our current ship information
         On a ship swap we don't get the full loadout so we have torely on our shipyard and hope we've seen this ship before
@@ -83,25 +111,28 @@ class Router():
 
         self.ship_id = sid
 
-        self.neutron_params['range'] = self.ships[sid].range
-        self.neutron_params['supercharge_multiplier'] = self.ships[sid].supercharge_multiplier
+        self.neutron_params["range"] = self.ships[sid].range
+        self.neutron_params["supercharge_multiplier"] = self.ships[
+            sid
+        ].supercharge_multiplier
         self.ship = self.ships[sid]
 
-
-    def set_ship(self, entry:dict) -> None:
-        """ Set the current ship details and update the UI """
-        ship:Ship = Ship(entry)
+    def set_ship(self, entry: dict) -> None:
+        """Set the current ship details and update the UI"""
+        ship: Ship = Ship(entry)
         self.ship = ship
         self.ship_id = str(ship.id)
-        self.neutron_params['supercharge_multiplier'] = ship.supercharge_multiplier
-        self.neutron_params['range'] = ship.range
+        self.neutron_params["supercharge_multiplier"] = ship.supercharge_multiplier
+        self.neutron_params["range"] = ship.range
         self.ships[self.ship_id] = ship
 
         if self.ship_id in self.shiplist:
             self.shiplist.remove(self.ship_id)
         self.shiplist.insert(0, self.ship_id)
         # Context.ui may be None in headless/test environments; guard the call.
-        if getattr(Context, 'ui', None) is not None and hasattr(Context.ui, 'switch_ship'):
+        if getattr(Context, "ui", None) is not None and hasattr(
+            Context.ui, "switch_ship"
+        ):
             try:
                 Context.ui.switch_ship(self.ship)
             except Exception as e:
@@ -109,85 +140,169 @@ class Router():
         else:
             Debug.logger.debug("No UI available to switch ship; skipping UI update.")
 
+    def jumped(self, system: str, entry: dict) -> None:
+        """Called after a carrier jump in order to update the route, the UI etc."""
 
-    def jumped(self, system:str, entry:dict) -> None:
-        """ Called after a carrier jump in order to update the route, the UI etc."""
-
-        if Context.route.route == [] or Context.route.fleetcarrier == True: return
-        Context.route.record_jump(entry.get('StarSystem', system), entry.get('JumpDist', 0))
+        if Context.route.route == [] or Context.route.fleetcarrier == True:
+            return
+        Context.route.record_jump(
+            entry.get("StarSystem", system), entry.get("JumpDist", 0)
+        )
 
         # End of the line?
         if Context.router.system == Context.route.destination():
             self._store_history()
 
-        if Context.route.update_route(0, entry.get('StarSystem', system)) > 0:
+        if Context.route.update_route(0, entry.get("StarSystem", system)) > 0:
             Debug.logger.debug(f"Updating route")
             Context.ui.update_waypoint()
 
+    def carrier_event(self, entry: dict) -> None:
+        """Note carrier jumps for a cooldown notification"""
+        if Context.route.route == [] or Context.route.fleetcarrier == False:
+            return
 
-    def carrier_event(self, entry:dict) -> None:
-        """ Note carrier jumps for a cooldown notification """
-        if Context.route.route == [] or Context.route.fleetcarrier == False: return
+        match entry.get("event"):
+            case "CarrierJumpRequest" if (
+                entry.get("SystemName", "") == Context.route.next_stop()
+            ):
+                self.carrier_id = entry.get("CarrierID", "")
+                self.carrier_state = "Jumping"
+                Debug.logger.debug(
+                    f"Carrier {self.carrier_id} jumping to {entry.get('SystemName', '')}"
+                )
+                if entry.get("DepartureTime"):
+                    self._start_carrier_jump(
+                        datetime.fromisoformat(entry.get("DepartureTime"))
+                    )
 
-        match entry.get('event'):
-            case 'CarrierJumpRequest' if entry.get('SystemName', '') == Context.route.next_stop():
-                self.carrier_id = entry.get('CarrierID', '')
-                self.carrier_state = 'Jumping'
-                Debug.logger.debug(f"Carrier {self.carrier_id} jumping to {entry.get('SystemName', '')}")
+            case "CarrierJumpCancelled" if self.carrier_id == entry.get(
+                "CarrierID", ""
+            ):
+                Debug.logger.debug(f"Carrier {self.carrier_id} jump canceled")
+                self._stop_carrier_jump()
+                self.carrier_state = "Cooldown"
+                cooldown = datetime.fromisoformat(entry.get("timestamp")) + timedelta(
+                    minutes=1
+                )
+                self._start_carrier_cooldown(cooldown)
 
-            case 'CarrierJumpCancelled' if self.carrier_id == entry.get('CarrierID', ''):
-                self.carrier_state = 'Cooldown'
-                Context.ui.frame.after(300000, lambda: self.cooldown_complete())
-
-            case 'CarrierLocation' if self.carrier_state == 'Jumping' and self.carrier_id == entry.get('CarrierID', '') and Context.ui.parent != None:
-                system:str = entry.get('StarSystem', '')
+            case "CarrierLocation" if (
+                self.carrier_state == "Jumping"
+                and self.carrier_id == entry.get("CarrierID", "")
+                and Context.ui.parent != None
+            ):
+                self._stop_carrier_jump()
+                system: str = entry.get("StarSystem", "")
                 Debug.logger.debug(f"Carrier is in {system}")
-                if Context.route.update_route(0, system) < 0: return
+                if Context.route.update_route(0, system) < 0:
+                    return
 
                 Debug.logger.debug(f"Updated route")
-                self.carrier_state = 'Cooldown'
+                self.carrier_state = "Cooldown"
                 self.system = system
-                Context.ui.frame.after(300000, lambda: self.cooldown_complete())
                 Context.ui.update_waypoint()
+                cooldown = datetime.fromisoformat(entry.get("timestamp")) + timedelta(
+                    minutes=5
+                )
+                self._start_carrier_cooldown(cooldown)
 
-            #case _ if self.carrier_id == entry.get('CarrierID', ''):
+            # case _ if self.carrier_id == entry.get('CarrierID', ''):
             #    self.carrier_state = 'Idle'
 
+    def _start_carrier_jump(self, depart_time: datetime) -> None:
 
-    def cooldown_complete(self) -> None:
-        """ Show an informational messagebox indicating a carrier cooldown has completed. """
-        Debug.logger.debug(f"Cooldown complete notification triggered.")
-        if Context.ui.parent == None: return
-        self.carrier_state = 'Idle'
-        Context.ui.cooldown_complete()
+        def _do_countdown(depart_time: datetime) -> None:
+            Debug.logger.debug(
+                f"Starting jump countdown thread with depart time of {depart_time}."
+            )
+            time_left = depart_time - datetime.now(tz=depart_time.tzinfo)
+            Context.overlay.body_text = f"{timedelta_str(time_left)} remaining..."
+            while not self._carrier_jump_thread_stop.wait(timeout=1):
+                time_left = depart_time - datetime.now(tz=depart_time.tzinfo)
+                Context.overlay.body_text = f"{timedelta_str(time_left)} remaining..."
+                if time_left.seconds <= 0:
+                    break
+            Debug.logger.debug("Carrier jump countdown thread is ending.")
 
+        self._stop_carrier_jump()
+        Context.overlay.title_text = f"Status: Jumping to {Context.route.next_stop()}"
+        self._carrier_jump_thread = threading.Thread(
+            target=_do_countdown, args=(depart_time,), daemon=True
+        )
+        self._carrier_jump_thread.start()
+
+    def _stop_carrier_jump(self) -> None:
+        if (
+            self._carrier_jump_thread is not None
+            and self._carrier_jump_thread.is_alive()
+        ):
+            # Existing thread is active, clean it up
+            self._carrier_jump_thread_stop.set()
+            self._carrier_jump_thread.join()
+            self._carrier_jump_thread_stop.clear()
+
+    def _start_carrier_cooldown(self, cooldown: datetime) -> None:
+
+        def _do_countdown(cooldown: datetime) -> None:
+            Debug.logger.debug(
+                f"Starting cooldown countdown thread with cooldown time of {cooldown}."
+            )
+            time_left = cooldown - datetime.now(tz=cooldown.tzinfo)
+            Context.overlay.body_text = f"{timedelta_str(time_left)} remaining..."
+            while not self._carrier_cooldown_thread_stop.wait(timeout=1):
+                time_left -= timedelta(seconds=1)
+                Context.overlay.body_text = f"{timedelta_str(time_left)} remaining..."
+                if time_left.seconds <= 0:
+                    break
+            self.carrier_state = "Idle"
+            Context.ui.update_waypoint()
+            Debug.logger.debug("Carrier cooldown thread is ending.")
+
+        self._stop_carrier_cooldown()
+        Context.overlay.title_text = "Status: Carrier Cooldown"
+        self._cooldown_thread = threading.Thread(
+            target=_do_countdown, args=(cooldown,), daemon=True
+        )
+        self._cooldown_thread.start()
+
+    def _stop_carrier_cooldown(self) -> None:
+        if (
+            self._carrier_cooldown_thread is not None
+            and self._carrier_cooldown_thread.is_alive()
+        ):
+            # Existing thread is active, clean it up
+            self._carrier_cooldown_thread_stop.set()
+            self._carrier_cooldown_thread.join()
+            self._carrier_cooldown_thread_stop.clear()
 
     def _store_history(self) -> None:
-        """ Upon route completion store src, dest and ship data """
+        """Upon route completion store src, dest and ship data"""
         Debug.logger.debug(f"Storing route history {self.src}, {self.dest}")
-        if self.src != '' and self.src:
+        if self.src != "" and self.src:
             self.history.insert(0, self.src)
-        if self.dest != '' and self.dest not in self.history:
+        if self.dest != "" and self.dest not in self.history:
             self.history.insert(0, self.dest)
         if "" in self.history:
             self.history.remove("")
-        self.history = list(dict.fromkeys(self.history))[:10] # Keep only last 10 unique entries
+        self.history = list(dict.fromkeys(self.history))[
+            :10
+        ]  # Keep only last 10 unique entries
         Debug.logger.debug(f"Route history updated: {self.history}")
 
-
-    def plot_route(self, which:str, params:dict) -> bool:
-        """ Initiate Spansh route plotting """
+    def plot_route(self, which: str, params: dict) -> bool:
+        """Initiate Spansh route plotting"""
 
         match which:
-            case 'Galaxy':
+            case "Galaxy":
                 url = SPANSH_GALAXY_ROUTE
-                self.src = params['source']
-                self.dest = params['destination']
+                self.src = params["source"]
+                self.dest = params["destination"]
                 self.galaxy_params = params
-            case 'Neutron':
-                url:str = SPANSH_ROUTE
-                self.src = params['from']
-                self.dest = params['to']
+            case "Neutron":
+                url: str = SPANSH_ROUTE
+                self.src = params["from"]
+                self.dest = params["to"]
                 self.neutron_params = params
             case _:
                 Debug.logger.error(f"Unknown route type {which}")
@@ -195,20 +310,28 @@ class Router():
 
         self.last_plot = which
 
-        Thread(target=self._plotter, args=(url, params), name="Neutron Dancer route plotting worker").start()
+        Thread(
+            target=self._plotter,
+            args=(url, params),
+            name="Neutron Dancer route plotting worker",
+        ).start()
         return True
 
-
-    def _plotter(self, url:str, params:dict) -> None:
-        """ Async function to run the Spansh query """
+    def _plotter(self, url: str, params: dict) -> None:
+        """Async function to run the Spansh query"""
         Debug.logger.debug(f"Plotting route {params} to {url}")
 
         self.cancel_plot = False
         try:
-            limit:int = int(params.get('max_time', 20))
-            results:Response = requests.post(url, data=params,
-                                             headers={'User-Agent': Context.plugin_useragent,
-                                                      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'})
+            limit: int = int(params.get("max_time", 20))
+            results: Response = requests.post(
+                url,
+                data=params,
+                headers={
+                    "User-Agent": Context.plugin_useragent,
+                    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+                },
+            )
 
             if results.status_code != 202:
                 self.plot_error(results)
@@ -216,35 +339,42 @@ class Router():
 
             tries = 0
             while tries < limit:
-                if config.shutting_down or self.cancel_plot: return # Quit
-                response:dict = json.loads(results.content)
-                job:str = response["job"]
+                if config.shutting_down or self.cancel_plot:
+                    return  # Quit
+                response: dict = json.loads(results.content)
+                job: str = response["job"]
 
-                results_url:str = f"{SPANSH_RESULTS}/{job}"
-                route_response:Response = requests.get(results_url, timeout=5)
+                results_url: str = f"{SPANSH_RESULTS}/{job}"
+                route_response: Response = requests.get(results_url, timeout=5)
                 if route_response.status_code != 202:
                     break
                 tries += 1
                 sleep(1)
 
-            if not route_response or route_response.status_code != 200 or self.cancel_plot:
+            if (
+                not route_response
+                or route_response.status_code != 200
+                or self.cancel_plot
+            ):
                 self.plot_error(route_response)
                 return
 
-            result:dict = json.loads(route_response.content)["result"]
-            res:list = result.get('jumps', result.get('system_jumps', []))
+            result: dict = json.loads(route_response.content)["result"]
+            res: list = result.get("jumps", result.get("system_jumps", []))
 
-            cols:list = []; hdrs:list = []; h:str
+            cols: list = []
+            hdrs: list = []
+            h: str
             for h in HEADERS:
-                k:str
+                k: str
                 for k in res[0].keys():
-                    if HEADER_MAP.get(k, '') == h:
+                    if HEADER_MAP.get(k, "") == h:
                         hdrs.append(h)
                         cols.append(k)
 
-            rte:list = []
+            rte: list = []
             for i, waypoint in enumerate(res):
-                r:list = []
+                r: list = []
                 for c in cols:
                     if re.match(r"^(\d+)?$", str(waypoint[c])):
                         r.append(round(int(waypoint[c]), 2))
@@ -261,42 +391,45 @@ class Router():
             Context.route.offset = 1 if Context.route.source() == self.system else 0
 
             Context.ui.ctc(Context.route.next_stop())
-            Context.ui.show_frame('Route')
+            Context.ui.show_frame("Route")
             self.save()
 
         except Exception as e:
             Debug.logger.error("Failed to plot route, exception info:", exc_info=e)
-            Context.ui.show_frame(Context.router.last_plot) # Return to the plot gui
+            Context.ui.show_frame(Context.router.last_plot)  # Return to the plot gui
             Context.ui.show_error(errs["plot_error"])
 
-
     @catch_exceptions
-    def plot_error(self, response:Response) -> None:
-        """ Parse the response from Spansh on a failed route query """
+    def plot_error(self, response: Response) -> None:
+        """Parse the response from Spansh on a failed route query"""
 
         Debug.logger.debug(f"Result: {response} {json.loads(response.content)}")
-        err:str = errs["no_response"]
-        #if response:
+        err: str = errs["no_response"]
+        # if response:
         #    Debug.logger.info(f"Server response: {response.json()}")
         #    err = errs["plot_error"]
 
-        if response.status_code in [400, 500] and "error" in json.loads(response.content).keys():
+        if (
+            response.status_code in [400, 500]
+            and "error" in json.loads(response.content).keys()
+        ):
             Debug.logger.info(f"Server response: {response.json()}")
             err = json.loads(response.content)["error"]
 
-        Context.ui.show_frame(Context.router.last_plot) # Return to the plot gui
+        Context.ui.show_frame(Context.router.last_plot)  # Return to the plot gui
         Context.ui.show_error(err)
         return
 
-
     @catch_exceptions
-    def import_route(self, filename:str = '') -> bool:
-        """ Load a route from a CSV """
+    def import_route(self, filename: str = "") -> bool:
+        """Load a route from a CSV"""
         try:
             Debug.logger.info("Importing route")
             if Context.csv == None or Context.csv.read(filename) == False:
                 Debug.logger.info(f"Failed to load route")
-                Context.ui.show_error(errs['no_filename'] if not Context.csv else Context.csv.error)
+                Context.ui.show_error(
+                    errs["no_filename"] if not Context.csv else Context.csv.error
+                )
                 return False
 
             Context.route = Route(Context.csv.headers, Context.csv.route)
@@ -310,126 +443,142 @@ class Router():
 
         except Exception as e:
             Debug.logger.error("Failed to load route:", exc_info=e)
-            Context.ui.show_error(errs['parse_error'])
+            Context.ui.show_error(errs["parse_error"])
             return False
 
-
     def export_route(self) -> bool:
-        """ Save a route to a CSV file """
+        """Save a route to a CSV file"""
         try:
-            if Context.csv == None or Context.csv.write(Context.route.hdrs, Context.route.route) == False:
+            if (
+                Context.csv == None
+                or Context.csv.write(Context.route.hdrs, Context.route.route) == False
+            ):
                 Debug.logger.error(f"Failed to save route")
-                Context.ui.show_error(errs['no_filename'])
+                Context.ui.show_error(errs["no_filename"])
                 return False
             return True
         except Exception as e:
             Debug.logger.error("Failed to save route:", exc_info=e)
-            Context.ui.show_error(errs['export_error'])
+            Context.ui.show_error(errs["export_error"])
             return False
 
-
     def _get_module_data(self) -> None:
-        """ Download module data from Coriolis """
+        """Download module data from Coriolis"""
         try:
             Debug.logger.debug(f"Getting module data")
-            modules:list = []
-            for key, url  in {"fsd": "https://raw.githubusercontent.com/EDCD/coriolis-data/master/modules/standard/frame_shift_drive.json",
-                              "gfsb": "https://raw.githubusercontent.com/EDCD/coriolis-data/master/modules/internal/guardian_fsd_booster.json",
-                              "ft": "https://raw.githubusercontent.com/EDCD/coriolis-data/master/modules/standard/fuel_tank.json"}.items():
-                r:Response = requests.get(url, timeout=10)
+            modules: list = []
+            for key, url in {
+                "fsd": "https://raw.githubusercontent.com/EDCD/coriolis-data/master/modules/standard/frame_shift_drive.json",
+                "gfsb": "https://raw.githubusercontent.com/EDCD/coriolis-data/master/modules/internal/guardian_fsd_booster.json",
+                "ft": "https://raw.githubusercontent.com/EDCD/coriolis-data/master/modules/standard/fuel_tank.json",
+            }.items():
+                r: Response = requests.get(url, timeout=10)
                 if r.status_code != 200:
-                    Debug.logger.info(f"Could not download FSD data (status code {r.status_code}): {r.text}")
+                    Debug.logger.info(
+                        f"Could not download FSD data (status code {r.status_code}): {r.text}"
+                    )
                     return
 
-                data:dict = json.loads(r.content)
+                data: dict = json.loads(r.content)
                 if data.get(key, []) == []:
-                    Debug.logger.error(f"No {key} found {json.loads(r.content)} {r.content}")
+                    Debug.logger.error(
+                        f"No {key} found {json.loads(r.content)} {r.content}"
+                    )
                     return
                 modules = modules + data.get(key, [])
 
             Context.modules = modules
 
             # Temporary hack since Coriolis doens't yet have the new MkII overcharge boosters
-            Context.modules.append({
-                "class": 8,
-                "cost": 82042060,
-                "fuelmul": 0.011,
-                "fuelpower": 2.5025,
-                "mass": 160,
-                "maxfuel": 6.8,
-                "optmass": 4670,
-                "power": 1.15,
-                "rating": "A",
-                "symbol": "Int_Hyperdrive_Overcharge_Size8_Class5_Overchargebooster_MkII",
-            })
+            Context.modules.append(
+                {
+                    "class": 8,
+                    "cost": 82042060,
+                    "fuelmul": 0.011,
+                    "fuelpower": 2.5025,
+                    "mass": 160,
+                    "maxfuel": 6.8,
+                    "optmass": 4670,
+                    "power": 1.15,
+                    "rating": "A",
+                    "symbol": "Int_Hyperdrive_Overcharge_Size8_Class5_Overchargebooster_MkII",
+                }
+            )
 
-            Debug.logger.debug(f"Downloaded {len(Context.modules)} FSD entries from Coriolis")
-            dir:Path = Path(Context.plugin_dir) / DATA_DIR
+            Debug.logger.debug(
+                f"Downloaded {len(Context.modules)} FSD entries from Coriolis"
+            )
+            dir: Path = Path(Context.plugin_dir) / DATA_DIR
             dir.mkdir(parents=True, exist_ok=True)
-            file:Path = Path(Context.plugin_dir) / DATA_DIR / 'module_data.json'
+            file: Path = Path(Context.plugin_dir) / DATA_DIR / "module_data.json"
 
-            with open(file, 'w') as outfile:
+            with open(file, "w") as outfile:
                 json.dump(Context.modules, outfile)
 
         except Exception as e:
-            Debug.logger.error("Failed to download FSD data, exception info:", exc_info=e)
-
+            Debug.logger.error(
+                "Failed to download FSD data, exception info:", exc_info=e
+            )
 
     @catch_exceptions
     def _load(self) -> None:
-        """ Load state from files """
+        """Load state from files"""
 
         # Get the FSD data from Coriolis' github repo
-        file = Path(Context.plugin_dir) / DATA_DIR / 'module_data.json'
+        file = Path(Context.plugin_dir) / DATA_DIR / "module_data.json"
         if file.exists():
             with open(file) as json_file:
                 Context.modules = json.load(json_file)
-                Debug.logger.debug(f"Loaded {len(Context.modules)} modules from local file")
+                Debug.logger.debug(
+                    f"Loaded {len(Context.modules)} modules from local file"
+                )
 
         if not file.exists() or file.stat().st_mtime < time() - 86400:
-            Debug.logger.debug("Module data is more than a day old, downloading fresh data")
-            thread:Thread = Thread(target=self._get_module_data, args=[], name="Neutron Dancer FSD data downloader")
+            Debug.logger.debug(
+                "Module data is more than a day old, downloading fresh data"
+            )
+            thread: Thread = Thread(
+                target=self._get_module_data,
+                args=[],
+                name="Neutron Dancer FSD data downloader",
+            )
             thread.start()
 
-        file:Path = Path(Context.plugin_dir) / DATA_DIR / 'route.json'
+        file: Path = Path(Context.plugin_dir) / DATA_DIR / "route.json"
         if file.exists():
             with open(file) as json_file:
                 self._from_dict(json.load(json_file))
 
-
     @catch_exceptions
     def save(self) -> None:
-        """ Save state to file """
+        """Save state to file"""
 
-        dir:Path = Path(Context.plugin_dir) / DATA_DIR
+        dir: Path = Path(Context.plugin_dir) / DATA_DIR
         dir.mkdir(parents=True, exist_ok=True)
-        file:Path = dir / 'route.json'
-        with open(file, 'w') as outfile:
+        file: Path = dir / "route.json"
+        with open(file, "w") as outfile:
             json.dump(self._as_dict(), outfile, indent=4)
 
-
     def _as_dict(self) -> dict:
-        """ Return a Dictionary representation of our data, suitable for serializing """
+        """Return a Dictionary representation of our data, suitable for serializing"""
 
-        save:dict = {k: getattr(self, k, v) for k, v in SAVE_VARS.items()}
+        save: dict = {k: getattr(self, k, v) for k, v in SAVE_VARS.items()}
 
-        save['ship'] = self.ship.to_dict() if self.ship else {}
-        save['ships'] = {k: ship.to_dict() for k, ship in self.ships.items()}
+        save["ship"] = self.ship.to_dict() if self.ship else {}
+        save["ships"] = {k: ship.to_dict() for k, ship in self.ships.items()}
         if Context.route != None:
-            save['route'] = Context.route.to_dict()
+            save["route"] = Context.route.to_dict()
         return save
 
-    def _from_dict(self, dict:dict) -> None:
-        """ Populate our data from a Dictionary that has been deserialized """
+    def _from_dict(self, dict: dict) -> None:
+        """Populate our data from a Dictionary that has been deserialized"""
 
         [setattr(self, k, dict.get(k, v)) for k, v in SAVE_VARS.items()]
-        (hdrs, route, offset, jumps) = dict.get('route', ([], [], 0, []))
+        (hdrs, route, offset, jumps) = dict.get("route", ([], [], 0, []))
         Context.route = Route(hdrs, route, offset, jumps)
-        self.ship = Ship(dict.get('ship', {}))
-        self.ships = {k: Ship(data) for k, data in dict.get('ships', {}).items()}
+        self.ship = Ship(dict.get("ship", {}))
+        self.ships = {k: Ship(data) for k, data in dict.get("ships", {}).items()}
 
         # Migrate
         if self.shiplist == [] and self.ships != {}:
             self.shiplist = [id for id in self.ships.keys()]
-
-

--- a/Router/ui.py
+++ b/Router/ui.py
@@ -10,31 +10,56 @@ from pathlib import Path
 import re
 import requests
 import json
-import myNotebook as nb # type: ignore
+import myNotebook as nb  # type: ignore
 
-from config import config # type: ignore
+from config import config  # type: ignore
 
 from utils.tooltip import Tooltip
 from utils.autocompleter import Autocompleter
 from utils.placeholder import Placeholder
 from utils.debug import Debug, catch_exceptions
-from utils.misc import frame, labelframe, button, label, radiobutton, combobox, scale, listbox, hfplus, PopupNotice
+from utils.misc import (
+    frame,
+    labelframe,
+    button,
+    label,
+    radiobutton,
+    combobox,
+    scale,
+    listbox,
+    hfplus,
+    PopupNotice,
+)
 from utils.tkrichtext import RichScrolledText
 
-from .constants import NAME, SPANSH_SYSTEMS, ASSET_DIR, FONT, BOLD, hdrs, lbls, btns, tts, errs
+from .constants import (
+    NAME,
+    SPANSH_SYSTEMS,
+    ASSET_DIR,
+    FONT,
+    BOLD,
+    hdrs,
+    lbls,
+    btns,
+    tts,
+    errs,
+)
 from .ship import Ship
 from .route import Route
 from .context import Context
 from .route_window import RouteWindow
 from .overlay import Overlay
-class UI():
+
+
+class UI:
     """
-        The main UI for the router.
-        It has three states with three different frames.
-          - Default, deliberately minimal for when the router isn't being used
-          - Plot, a plot entry frame with neutron and galaxy route variants
-          - Route, displays the route navigation
+    The main UI for the router.
+    It has three states with three different frames.
+      - Default, deliberately minimal for when the router isn't being used
+      - Plot, a plot entry frame with neutron and galaxy route variants
+      - Route, displays the route navigation
     """
+
     # Singleton pattern
     _instance = None
 
@@ -43,223 +68,320 @@ class UI():
             cls._instance = super().__new__(cls)
         return cls._instance
 
-
-    def __init__(self, parent:tk.Widget|None = None) -> None:
+    def __init__(self, parent: tk.Widget | None = None) -> None:
         # Only initialize if it's the first time
-        if hasattr(self, '_initialized'): return
+        if hasattr(self, "_initialized"):
+            return
 
         # Initialise the UI
         if parent == None:
             Debug.logger.info(f"No parent")
             return
 
-        self.frwidth:int = int(375 * (config.get_int('ui_scale') / 100))
-        self.parent:tk.Widget|None = parent
-        self.window_route:RouteWindow = RouteWindow(self.parent.winfo_toplevel())
+        self.frwidth: int = int(375 * (config.get_int("ui_scale") / 100))
+        self.parent: tk.Widget | None = parent
+        self.window_route: RouteWindow = RouteWindow(self.parent.winfo_toplevel())
 
-        self.frame:tk.Frame = frame(parent, borderwidth=2)
+        self.frame: tk.Frame = frame(parent, borderwidth=2)
         self.frame.grid(sticky=tk.NSEW)
 
-        self.update:tk.Label
+        self.update: tk.Label
 
-        self.help_img:tk.PhotoImage = tk.PhotoImage(file=os.path.join(Context.plugin_dir, ASSET_DIR, "help.png"))
-        self.fuel_img:tk.PhotoImage = tk.PhotoImage(file=os.path.join(Context.plugin_dir, ASSET_DIR, "fuel.png"))
-        #self.countdown_img:tk.PhotoImage = tk.PhotoImage(file=os.path.join(Context.plugin_dir, ASSET_DIR, "countdown.png"))
-        #self.timer_img:tk.PhotoImage = tk.PhotoImage(file=os.path.join(Context.plugin_dir, ASSET_DIR, "timer.png"))
+        self.help_img: tk.PhotoImage = tk.PhotoImage(
+            file=os.path.join(Context.plugin_dir, ASSET_DIR, "help.png")
+        )
+        self.fuel_img: tk.PhotoImage = tk.PhotoImage(
+            file=os.path.join(Context.plugin_dir, ASSET_DIR, "fuel.png")
+        )
+        # self.countdown_img:tk.PhotoImage = tk.PhotoImage(file=os.path.join(Context.plugin_dir, ASSET_DIR, "countdown.png"))
+        # self.timer_img:tk.PhotoImage = tk.PhotoImage(file=os.path.join(Context.plugin_dir, ASSET_DIR, "timer.png"))
 
-        self.error_lbl:tk.Label|ttk.Label = label(self.frame, text="", foreground='red')
+        self.error_lbl: tk.Label | ttk.Label = label(
+            self.frame, text="", foreground="red"
+        )
         self.error_lbl.grid(row=10, column=0, columnspan=2, padx=5, sticky=tk.W)
         self.hide_error()
 
-        self.router:tk.StringVar = tk.StringVar()
-        self.router.set('Neutron')  # Set default value
+        self.router: tk.StringVar = tk.StringVar()
+        self.router.set("Neutron")  # Set default value
 
-        self.progbar:ttk.Progressbar # Overall progress bar
+        self.progbar: ttk.Progressbar  # Overall progress bar
 
-        self.title_fr:tk.Frame = self._create_title_fr(self.frame)
-        self.neutron_fr:tk.Frame = self._create_neutron_fr(self.frame)
-        self.galaxy_fr:tk.Frame = self._create_galaxy_fr(self.frame)
-        self.busy_fr:tk.Frame = self._create_busy_fr(self.frame)
-        self.route_fr:tk.Frame = self._create_route_fr(self.frame)
+        self.title_fr: tk.Frame = self._create_title_fr(self.frame)
+        self.neutron_fr: tk.Frame = self._create_neutron_fr(self.frame)
+        self.galaxy_fr: tk.Frame = self._create_galaxy_fr(self.frame)
+        self.busy_fr: tk.Frame = self._create_busy_fr(self.frame)
+        self.route_fr: tk.Frame = self._create_route_fr(self.frame)
 
-        self.sub_fr:tk.Frame = self.title_fr
-        self.show_frame('Route' if Context.route.route != [] else 'Default')
+        self.sub_fr: tk.Frame = self.title_fr
+        self.show_frame("Route" if Context.route.route != [] else "Default")
 
         # Wait a while before deciding if we should show the update text
         parent.after(30000, lambda: self.show_update())
         self._initialized = True
 
-
     @catch_exceptions
     def show_update(self) -> None:
-        """ Display the update text if appropriate"""
-        if Context.updater.update_available == False or Context.updater.install_update == False or Context.updater.zip_downloaded == "":
+        """Display the update text if appropriate"""
+        if (
+            Context.updater.update_available == False
+            or Context.updater.install_update == False
+            or Context.updater.zip_downloaded == ""
+        ):
             return
 
-        text:str = lbls['update_available'].format(v=str(Context.updater.update_version))
-        self.update = tk.Label(self.frame, text=text, anchor=tk.NW, justify=tk.LEFT, foreground='blue', font=FONT, cursor='hand2')
+        text: str = lbls["update_available"].format(
+            v=str(Context.updater.update_version)
+        )
+        self.update = tk.Label(
+            self.frame,
+            text=text,
+            anchor=tk.NW,
+            justify=tk.LEFT,
+            foreground="blue",
+            font=FONT,
+            cursor="hand2",
+        )
         if Context.updater.releasenotes != "":
-            Tooltip(self.update, text=tts["releasenotes"].format(c=Context.updater.releasenotes))
+            Tooltip(
+                self.update,
+                text=tts["releasenotes"].format(c=Context.updater.releasenotes),
+            )
         self.update.bind("<Button-1>", partial(self.cancel_update))
         self.update.grid(row=0, column=0, columnspan=2, padx=5, pady=5, sticky=tk.W)
 
-
     @catch_exceptions
-    def cancel_update(self, tkEvent = None) -> None:
-        """ Cancel the update if they click """
-        #webbrowser.open(GH_LATEST)
+    def cancel_update(self, tkEvent=None) -> None:
+        """Cancel the update if they click"""
+        # webbrowser.open(GH_LATEST)
         Context.updater.install_update = False
         self.update.destroy()
 
-
     @catch_exceptions
-    def show_frame(self, which:str = 'Default', destroy:bool = False) -> None:
-        """ Display the chosen frame, recreating it if necessary """
+    def show_frame(self, which: str = "Default", destroy: bool = False) -> None:
+        """Display the chosen frame, recreating it if necessary"""
         self.hide_error()
         self._show_busy_gui(False)
         Context.router.cancel_plot = True
-        Overlay().show_message('Default', ["title", "", "normal", ""], ttl=1)
+        Context.overlay.title_text = ""
+        Context.overlay.body_text = ""
         self.sub_fr.grid_remove()
 
-        Context.router.neutron_params['range'] = f"{Context.router.ship.get_range(Context.router.cargo):.2f}" if Context.router.ship else "32.0"
-        Context.router.neutron_params['supercharge_multiplier'] = Context.router.ship.supercharge_multiplier if Context.router.ship else 4
-        if Context.router.cargo != 0 and Context.router.cargo != Context.router.galaxy_params.get('cargo', 0):
-            Context.router.galaxy_params['cargo'] = Context.router.cargo
+        Context.router.neutron_params["range"] = (
+            f"{Context.router.ship.get_range(Context.router.cargo):.2f}"
+            if Context.router.ship
+            else "32.0"
+        )
+        Context.router.neutron_params["supercharge_multiplier"] = (
+            Context.router.ship.supercharge_multiplier if Context.router.ship else 4
+        )
+        if (
+            Context.router.cargo != 0
+            and Context.router.cargo != Context.router.galaxy_params.get("cargo", 0)
+        ):
+            Context.router.galaxy_params["cargo"] = Context.router.cargo
 
         match which:
-            case 'Route':
+            case "Route":
                 self.sub_fr = self.route_fr
                 self.update_waypoint()
 
-            case 'Neutron':
-                self.source_ac.set_text(self.gal_source_ac.get(), self.gal_source_ac.get() == lbls["source_system"]) # Update when we switch views
-                self.dest_ac.set_text(self.gal_dest_ac.get(), self.gal_dest_ac.get() == lbls["dest_system"]) # Update when we switch views
+            case "Neutron":
+                self.source_ac.set_text(
+                    self.gal_source_ac.get(),
+                    self.gal_source_ac.get() == lbls["source_system"],
+                )  # Update when we switch views
+                self.dest_ac.set_text(
+                    self.gal_dest_ac.get(),
+                    self.gal_dest_ac.get() == lbls["dest_system"],
+                )  # Update when we switch views
                 self.sub_fr = self.neutron_fr
-                self.router.set('Neutron')
+                self.router.set("Neutron")
 
-            case 'Galaxy':
-                self.gal_source_ac.set_text(self.source_ac.get(), self.source_ac.get() == lbls["source_system"]) # Update when we switch views
-                self.gal_dest_ac.set_text(self.dest_ac.get(), self.dest_ac.get() == lbls["dest_system"]) # Update when we switch views
+            case "Galaxy":
+                self.gal_source_ac.set_text(
+                    self.source_ac.get(), self.source_ac.get() == lbls["source_system"]
+                )  # Update when we switch views
+                self.gal_dest_ac.set_text(
+                    self.dest_ac.get(), self.dest_ac.get() == lbls["dest_system"]
+                )  # Update when we switch views
                 self.sub_fr = self.galaxy_fr
-                self.router.set('Galaxy')
+                self.router.set("Galaxy")
 
             case _:
                 self.sub_fr = self.title_fr
 
         self.sub_fr.grid(row=2, column=0, sticky=tk.NSEW)
 
-
-    def _create_title_fr(self, parent:tk.Frame) -> tk.Frame:
-        """ Create the base/title frame """
-        title_fr:tk.Frame = frame(parent)
-        col:int = 0; row:int = 0
-        self.lbl:tk.Label|ttk.Label = label(title_fr, text=lbls["plot_title"], font=BOLD)
-        self.lbl.grid(row=row, column=col, padx=(0,5), pady=5)
+    def _create_title_fr(self, parent: tk.Frame) -> tk.Frame:
+        """Create the base/title frame"""
+        title_fr: tk.Frame = frame(parent)
+        col: int = 0
+        row: int = 0
+        self.lbl: tk.Label | ttk.Label = label(
+            title_fr, text=lbls["plot_title"], font=BOLD
+        )
+        self.lbl.grid(row=row, column=col, padx=(0, 5), pady=5)
         col += 1
-        plot_gui_btn:tk.Button|ttk.Button = button(title_fr, text=" "+btns["plot_route"]+" ", command=lambda: self.show_frame(Context.router.last_plot))
+        plot_gui_btn: tk.Button | ttk.Button = button(
+            title_fr,
+            text=" " + btns["plot_route"] + " ",
+            command=lambda: self.show_frame(Context.router.last_plot),
+        )
         plot_gui_btn.grid(row=row, column=col, sticky=tk.W)
 
         return title_fr
 
+    def _create_busy_fr(self, parent: tk.Frame) -> tk.Frame:
+        """Spinner image for route plotting"""
 
-    def _create_busy_fr(self, parent:tk.Frame) -> tk.Frame:
-        """ Spinner image for route plotting """
+        image: str = os.path.join(
+            Context.plugin_dir,
+            ASSET_DIR,
+            (
+                "progress_animation_light.gif"
+                if config.get_int("theme") == 0
+                else "progress_animation_dark.gif"
+            ),
+        )
+        self.frameCnt: int = 44
+        self.frameSpd: int = 50
 
-        image:str = os.path.join(Context.plugin_dir, ASSET_DIR, "progress_animation_light.gif" if config.get_int('theme') == 0 else "progress_animation_dark.gif")
-        self.frameCnt:int = 44
-        self.frameSpd:int = 50
-
-        self.frames:list = [tk.PhotoImage(file=image, format='gif -index %i' %(i)) for i in range(self.frameCnt)]
-        busy_fr:tk.Frame = frame(parent)
-        self.route_lbl:ttk.Label|tk.Label = label(busy_fr, text=lbls["plotting"].format(s=Context.router.src, d=Context.router.dest), justify=tk.CENTER, font=BOLD)
+        self.frames: list = [
+            tk.PhotoImage(file=image, format="gif -index %i" % (i))
+            for i in range(self.frameCnt)
+        ]
+        busy_fr: tk.Frame = frame(parent)
+        self.route_lbl: ttk.Label | tk.Label = label(
+            busy_fr,
+            text=lbls["plotting"].format(s=Context.router.src, d=Context.router.dest),
+            justify=tk.CENTER,
+            font=BOLD,
+        )
         self.route_lbl.pack(pady=5, anchor=tk.CENTER)
-        self.busyimg:ttk.Label|tk.Label = label(busy_fr, image=self.frames[0], justify=tk.CENTER)
+        self.busyimg: ttk.Label | tk.Label = label(
+            busy_fr, image=self.frames[0], justify=tk.CENTER
+        )
         self.busyimg.pack(anchor=tk.CENTER, fill=tk.BOTH, pady=10)
-        cancel:tk.Button|ttk.Button = button(busy_fr, text=btns["cancel"], command=lambda: self.show_frame(Context.router.last_plot))
+        cancel: tk.Button | ttk.Button = button(
+            busy_fr,
+            text=btns["cancel"],
+            command=lambda: self.show_frame(Context.router.last_plot),
+        )
         cancel.pack(anchor=tk.CENTER)
         return busy_fr
 
-
-    def _plot_switcher(self, fr:tk.Frame, row:int, col:int) -> None:
-        """ Switch between the two route plotters """
-        sfr:tk.Frame = frame(fr, width=self.frwidth)
-        r1:tk.Radiobutton|ttk.Radiobutton = radiobutton(sfr, text=lbls["neutron_router"], variable=self.router, value='Neutron', command=lambda: self.show_frame('Neutron'))
+    def _plot_switcher(self, fr: tk.Frame, row: int, col: int) -> None:
+        """Switch between the two route plotters"""
+        sfr: tk.Frame = frame(fr, width=self.frwidth)
+        r1: tk.Radiobutton | ttk.Radiobutton = radiobutton(
+            sfr,
+            text=lbls["neutron_router"],
+            variable=self.router,
+            value="Neutron",
+            command=lambda: self.show_frame("Neutron"),
+        )
         r1.grid(row=0, column=0, padx=5, pady=5)
-        r2:tk.Radiobutton|ttk.Radiobutton = radiobutton(sfr, text=lbls["galaxy_router"], variable=self.router, value='Galaxy', command=lambda: self.show_frame('Galaxy'))
+        r2: tk.Radiobutton | ttk.Radiobutton = radiobutton(
+            sfr,
+            text=lbls["galaxy_router"],
+            variable=self.router,
+            value="Galaxy",
+            command=lambda: self.show_frame("Galaxy"),
+        )
         r2.grid(row=0, column=1, padx=5, pady=5)
         # Use help.png image if available (prefer transparent PNG), fallback to text '!'
-        r3:tk.Button|ttk.Button = button(sfr, image=self.help_img, cursor="hand2", command=lambda: self._show_help())
+        r3: tk.Button | ttk.Button = button(
+            sfr, image=self.help_img, cursor="hand2", command=lambda: self._show_help()
+        )
         r3.grid(row=0, column=2, padx=5, pady=5)
         sfr.grid(row=row, column=col, columnspan=3, sticky=tk.EW)
 
-
     @catch_exceptions
     def _show_help(self) -> None:
-        """ Help window """
+        """Help window"""
 
-        if self.parent == None: return
+        if self.parent == None:
+            return
 
-        if hasattr(self, 'help') and self.help.winfo_exists():
+        if hasattr(self, "help") and self.help.winfo_exists():
             self.help.lift()
             return
 
-        self.help:tk.Toplevel = tk.Toplevel(self.parent.winfo_toplevel())
+        self.help: tk.Toplevel = tk.Toplevel(self.parent.winfo_toplevel())
         self.help.title(f"{NAME} – {lbls['help']}")
-        geometry:str = Context.router.window_geometries.get('help', "650x750")
+        geometry: str = Context.router.window_geometries.get("help", "650x750")
         self.help.geometry(geometry)
         self.help.protocol("WM_DELETE_WINDOW", self.close)
 
-        file:Path = Path(Context.plugin_dir, ASSET_DIR, "help.md")
-        text:str = ""
+        file: Path = Path(Context.plugin_dir, ASSET_DIR, "help.md")
+        text: str = ""
         with open(file, encoding="utf-8") as infile:
             text = infile.read()
         text = text.replace("{version}", str(Context.plugin_version))
-        html_label:RichScrolledText = RichScrolledText(self.help, markdown=text)
+        html_label: RichScrolledText = RichScrolledText(self.help, markdown=text)
         html_label.pack(fill="both", expand=True, ipadx=5, ipady=5)
         html_label.fit_height()
 
     def close(self) -> None:
-        """ On close save our geometry """
-        Context.router.window_geometries['help'] = self.help.winfo_geometry()
+        """On close save our geometry"""
+        Context.router.window_geometries["help"] = self.help.winfo_geometry()
         self.help.destroy()
         return
 
+    def _create_galaxy_fr(self, parent: tk.Frame) -> tk.Frame:
+        """Create the galaxy route plotting frame"""
 
-    def _create_galaxy_fr(self, parent:tk.Frame) -> tk.Frame:
-        """ Create the galaxy route plotting frame """
+        plot_fr: tk.Frame = frame(parent, width=self.frwidth)
+        row: int = 2
+        col: int = 0
 
-        plot_fr:tk.Frame = frame(parent, width=self.frwidth)
-        row:int = 2
-        col:int = 0
-
-        params:dict = Context.router.galaxy_params
+        params: dict = Context.router.galaxy_params
 
         # Define the popup menu additions
-        srcmenu:dict = {Context.router.system: [self.menu_callback, 'src']} if Context.router.system != '' else {}
-        destmenu:dict = {}
+        srcmenu: dict = (
+            {Context.router.system: [self.menu_callback, "src"]}
+            if Context.router.system != ""
+            else {}
+        )
+        destmenu: dict = {}
 
-        if Context.router.system != '':
-            srcmenu[Context.router.system] = [self.menu_callback, 'src']
+        if Context.router.system != "":
+            srcmenu[Context.router.system] = [self.menu_callback, "src"]
         for sys in Context.router.history:
             if sys not in srcmenu:
-                srcmenu[sys] = [self.menu_callback, 'src']
+                srcmenu[sys] = [self.menu_callback, "src"]
             if sys not in destmenu:
-                destmenu[sys] = [self.menu_callback, 'dest']
+                destmenu[sys] = [self.menu_callback, "dest"]
 
         self._plot_switcher(plot_fr, row, col)
 
-        row +=1; col = 0
+        row += 1
+        col = 0
 
         # First row
-        self.gal_source_ac = Autocompleter(plot_fr, lbls["source_system"], width=30, menu=srcmenu, func=self.query_systems)
+        self.gal_source_ac = Autocompleter(
+            plot_fr,
+            lbls["source_system"],
+            width=30,
+            menu=srcmenu,
+            func=self.query_systems,
+        )
         Tooltip(self.gal_source_ac, tts["source_system"])
-        if Context.router.src != '': self.set_entry(self.gal_source_ac, Context.router.src)
+        if Context.router.src != "":
+            self.set_entry(self.gal_source_ac, Context.router.src)
         self.gal_source_ac.grid(row=row, column=col, columnspan=2, padx=5, pady=5)
         col += 2
 
-        self.optionlist:list = ['is_supercharged', 'use_supercharge', 'use_injections', 'exclude_secondary', 'refuel_every_scoopable']
-        self.gallb:tk.Listbox = listbox(plot_fr, [lbls[v] for v in self.optionlist])
-        Tooltip(self.gallb, tts['galaxy_options'])
+        self.optionlist: list = [
+            "is_supercharged",
+            "use_supercharge",
+            "use_injections",
+            "exclude_secondary",
+            "refuel_every_scoopable",
+        ]
+        self.gallb: tk.Listbox = listbox(plot_fr, [lbls[v] for v in self.optionlist])
+        Tooltip(self.gallb, tts["galaxy_options"])
 
         for i, item in enumerate(self.optionlist):
             if params.get(item, False) == True:
@@ -267,30 +389,48 @@ class UI():
         self.gallb.grid(row=row, column=col, rowspan=3, padx=5, pady=5)
 
         # Row two
-        row += 1; col = 0
-        self.gal_dest_ac = Autocompleter(plot_fr, lbls["dest_system"], width=30, menu=destmenu, func=self.query_systems)
+        row += 1
+        col = 0
+        self.gal_dest_ac = Autocompleter(
+            plot_fr,
+            lbls["dest_system"],
+            width=30,
+            menu=destmenu,
+            func=self.query_systems,
+        )
         Tooltip(self.gal_dest_ac, tts["dest_system"])
-        if Context.router.dest != '': self.set_entry(self.gal_dest_ac, Context.router.dest)
+        if Context.router.dest != "":
+            self.set_entry(self.gal_dest_ac, Context.router.dest)
         self.gal_dest_ac.grid(row=row, column=col, columnspan=2, padx=5, pady=5)
 
         # Row three
-        row += 1; col = 0
-        if Context.router.shiplist == []: self.show_error(errs["no_ships"])
-        names:list = [Context.router.ships[id].name for id in Context.router.shiplist if id in Context.router.ships]
-        init:str = params.get('ship_build', {}).get('ShipName', '')
+        row += 1
+        col = 0
+        if Context.router.shiplist == []:
+            self.show_error(errs["no_ships"])
+        names: list = [
+            Context.router.ships[id].name
+            for id in Context.router.shiplist
+            if id in Context.router.ships
+        ]
+        init: str = params.get("ship_build", {}).get("ShipName", "")
         if init == "" and names != []:
             init = names[0]
 
-        self.ship:tk.StringVar = tk.StringVar(plot_fr, value=init)
-        self.shipdd:ttk.Combobox|tk.OptionMenu = combobox(plot_fr, self.ship, values=names, width=10)
+        self.ship: tk.StringVar = tk.StringVar(plot_fr, value=init)
+        self.shipdd: ttk.Combobox | tk.OptionMenu = combobox(
+            plot_fr, self.ship, values=names, width=10
+        )
         Tooltip(self.shipdd, tts["select_ship"])
         self.shipdd.grid(row=row, column=col, padx=5, pady=5)
 
         col += 1
 
-        self.cargo_entry:Placeholder = Placeholder(plot_fr, lbls['cargo'], width=11, justify=tk.CENTER)
-        if params.get('cargo', 0) != 0:
-            self.set_entry(self.cargo_entry, str(params.get('cargo', 0)))
+        self.cargo_entry: Placeholder = Placeholder(
+            plot_fr, lbls["cargo"], width=11, justify=tk.CENTER
+        )
+        if params.get("cargo", 0) != 0:
+            self.set_entry(self.cargo_entry, str(params.get("cargo", 0)))
         elif Context.router.cargo != 0:
             self.set_entry(self.cargo_entry, str(Context.router.cargo))
 
@@ -298,343 +438,472 @@ class UI():
         Tooltip(self.cargo_entry, tts["cargo"])
 
         # Row 4
-        row += 1; col = 0
-        algorithms:list = ['Fuel', 'Fuel Jumps', 'Guided', 'Optimistic', 'Pessimistic']
-        self.algorithm:tk.StringVar = tk.StringVar(plot_fr, value=params.get('algorithm', 'Optimistic'))
-        algodd:ttk.Combobox|tk.OptionMenu = combobox(plot_fr, self.algorithm, values=algorithms, width=10)
+        row += 1
+        col = 0
+        algorithms: list = ["Fuel", "Fuel Jumps", "Guided", "Optimistic", "Pessimistic"]
+        self.algorithm: tk.StringVar = tk.StringVar(
+            plot_fr, value=params.get("algorithm", "Optimistic")
+        )
+        algodd: ttk.Combobox | tk.OptionMenu = combobox(
+            plot_fr, self.algorithm, values=algorithms, width=10
+        )
         Tooltip(algodd, tts["select_algorithm"])
         algodd.grid(row=row, column=col, padx=5, pady=5)
 
         col += 1
-        self.fuel_res:Placeholder = Placeholder(plot_fr, lbls['fuel_reserve'], width=11, justify=tk.CENTER)
-        if params.get('fuel_reserve', 0) != 0:
-            self.set_entry(self.fuel_res, str(params.get('fuel_reserve', 0)))
+        self.fuel_res: Placeholder = Placeholder(
+            plot_fr, lbls["fuel_reserve"], width=11, justify=tk.CENTER
+        )
+        if params.get("fuel_reserve", 0) != 0:
+            self.set_entry(self.fuel_res, str(params.get("fuel_reserve", 0)))
         Tooltip(self.fuel_res, tts["fuel_reserve"])
         self.fuel_res.grid(row=row, column=col, padx=5, pady=5)
 
         col += 1
-        self.time_limit:tk.Scale|ttk.Scale = scale(plot_fr, from_=60, to=120, resolution=5, orient=tk.HORIZONTAL)
+        self.time_limit: tk.Scale | ttk.Scale = scale(
+            plot_fr, from_=60, to=120, resolution=5, orient=tk.HORIZONTAL
+        )
         Tooltip(self.time_limit, tts["calc_time"])
         self.time_limit.grid(row=row, column=col, pady=5)
-        self.time_limit.set(params.get('max_time', 60))
+        self.time_limit.set(params.get("max_time", 60))
 
         # Row 5
-        row += 1; col = 0
-        btn_frame:tk.Frame = frame(plot_fr)
+        row += 1
+        col = 0
+        btn_frame: tk.Frame = frame(plot_fr)
         btn_frame.grid(row=row, column=col, columnspan=3, sticky=tk.W)
 
-        r = 0; col = 0
-        self.gal_import_route_btn:tk.Button|ttk.Button = button(btn_frame, text=btns["import_route"], command=lambda: self.import_route())
+        r = 0
+        col = 0
+        self.gal_import_route_btn: tk.Button | ttk.Button = button(
+            btn_frame, text=btns["import_route"], command=lambda: self.import_route()
+        )
         self.gal_import_route_btn.grid(row=r, column=col, padx=5, sticky=tk.W)
         col += 1
 
-        self.gal_plot_route_btn:tk.Button|ttk.Button = button(btn_frame, text=btns["calculate_route"], command=lambda: self.galaxy_plot())
+        self.gal_plot_route_btn: tk.Button | ttk.Button = button(
+            btn_frame, text=btns["calculate_route"], command=lambda: self.galaxy_plot()
+        )
         self.gal_plot_route_btn.grid(row=r, column=col, padx=5, sticky=tk.W)
         col += 1
 
-        self.gal_cancel_plot:tk.Button|ttk.Button = button(btn_frame, text=btns["cancel"], command=lambda: self.show_frame('Default'))
+        self.gal_cancel_plot: tk.Button | ttk.Button = button(
+            btn_frame, text=btns["cancel"], command=lambda: self.show_frame("Default")
+        )
         self.gal_cancel_plot.grid(row=r, column=col, padx=5, sticky=tk.W)
 
         return plot_fr
 
+    def _create_neutron_fr(self, parent: tk.Frame) -> tk.Frame:
+        """Create the neutron route plotting frame"""
 
-    def _create_neutron_fr(self, parent:tk.Frame) -> tk.Frame:
-        """ Create the neutron route plotting frame """
+        plot_fr: tk.Frame = frame(parent, width=self.frwidth)
+        row: int = 2
+        col: int = 0
 
-        plot_fr:tk.Frame = frame(parent, width=self.frwidth)
-        row:int = 2
-        col:int = 0
-
-        params:dict = Context.router.neutron_params
+        params: dict = Context.router.neutron_params
 
         # Define the popup menu additions
-        srcmenu:dict = {Context.router.system: [self.menu_callback, 'src']} if Context.router.system != '' else {}
-        destmenu:dict = {}
-        shipmenu:dict = {}
+        srcmenu: dict = (
+            {Context.router.system: [self.menu_callback, "src"]}
+            if Context.router.system != ""
+            else {}
+        )
+        destmenu: dict = {}
+        shipmenu: dict = {}
 
-        if Context.router.system != '':
-            srcmenu[Context.router.system] = [self.menu_callback, 'src']
+        if Context.router.system != "":
+            srcmenu[Context.router.system] = [self.menu_callback, "src"]
         for sys in Context.router.history:
             if sys not in srcmenu:
-                srcmenu[sys] = [self.menu_callback, 'src']
+                srcmenu[sys] = [self.menu_callback, "src"]
             if sys not in destmenu:
-                destmenu[sys] = [self.menu_callback, 'dest']
+                destmenu[sys] = [self.menu_callback, "dest"]
 
         # Create right click menu
         for id in Context.router.shiplist[:10]:
             if id in Context.router.ships:
-                shipmenu[Context.router.ships[id].name] = [self.menu_callback, 'ship']
+                shipmenu[Context.router.ships[id].name] = [self.menu_callback, "ship"]
 
         if shipmenu != {}:
-            self.menu:tk.Menu = tk.Menu(plot_fr, tearoff=0)
+            self.menu: tk.Menu = tk.Menu(plot_fr, tearoff=0)
             for m, f in shipmenu.items():
                 self.menu.add_command(label=m, command=partial(*f, m))
 
         self._plot_switcher(plot_fr, row, col)
 
-        row +=1; col = 0
-        self.source_ac = Autocompleter(plot_fr, lbls["source_system"], width=30, menu=srcmenu, func=self.query_systems)
+        row += 1
+        col = 0
+        self.source_ac = Autocompleter(
+            plot_fr,
+            lbls["source_system"],
+            width=30,
+            menu=srcmenu,
+            func=self.query_systems,
+        )
         Tooltip(self.source_ac, tts["source_system"])
-        if Context.router.src != '': self.set_entry(self.source_ac, Context.router.src)
+        if Context.router.src != "":
+            self.set_entry(self.source_ac, Context.router.src)
         self.source_ac.grid(row=row, column=col, columnspan=2)
         col += 2
 
-        self.range_entry:Placeholder = Placeholder(plot_fr, lbls['range'], width=11, menu=shipmenu, justify=tk.CENTER)
+        self.range_entry: Placeholder = Placeholder(
+            plot_fr, lbls["range"], width=11, menu=shipmenu, justify=tk.CENTER
+        )
         self.range_entry.grid(row=row, column=col)
         Tooltip(self.range_entry, tts["range"])
         # Check if we're having a valid range on the fly
-        self.range_entry.var.trace_add('write', self.check_range)
-        self.range_entry.set_text(str(params.get('range', "32.00")), str(params.get('range', "32.00")) == "32.00")
+        self.range_entry.var.trace_add("write", self.check_range)
+        self.range_entry.set_text(
+            str(params.get("range", "32.00")),
+            str(params.get("range", "32.00")) == "32.00",
+        )
 
-        row += 1; col = 0
-        self.dest_ac = Autocompleter(plot_fr, lbls["dest_system"], width=30, menu=destmenu, func=self.query_systems)
+        row += 1
+        col = 0
+        self.dest_ac = Autocompleter(
+            plot_fr,
+            lbls["dest_system"],
+            width=30,
+            menu=destmenu,
+            func=self.query_systems,
+        )
         Tooltip(self.dest_ac, tts["dest_system"])
-        if Context.router.dest != '': self.set_entry(self.dest_ac, Context.router.dest)
+        if Context.router.dest != "":
+            self.set_entry(self.dest_ac, Context.router.dest)
         self.dest_ac.grid(row=row, column=col, columnspan=2)
         col += 2
 
-        self.efficiency_slider:tk.Scale|ttk.Scale = scale(plot_fr, from_=0, to=100, resolution=5, orient=tk.HORIZONTAL)
+        self.efficiency_slider: tk.Scale | ttk.Scale = scale(
+            plot_fr, from_=0, to=100, resolution=5, orient=tk.HORIZONTAL
+        )
         Tooltip(self.efficiency_slider, tts["efficiency"])
         self.efficiency_slider.grid(row=row, column=col)
-        self.efficiency_slider.set(params.get('efficiency', 60))
+        self.efficiency_slider.set(params.get("efficiency", 60))
 
-        row += 1; col = 0
-        self.multiplier = tk.IntVar() # Or StringVar() for string values
-        self.multiplier.set(params.get('supercharge_multiplier', 4))  # Set default value
+        row += 1
+        col = 0
+        self.multiplier = tk.IntVar()  # Or StringVar() for string values
+        self.multiplier.set(
+            params.get("supercharge_multiplier", 4)
+        )  # Set default value
 
         # Create radio buttons
-        l1:tk.Label|ttk.Label = label(plot_fr, text=lbls["supercharge_label"])
+        l1: tk.Label | ttk.Label = label(plot_fr, text=lbls["supercharge_label"])
         l1.grid(row=row, column=col, padx=5, pady=5)
         col += 1
-        r1:tk.Radiobutton|ttk.Radiobutton = radiobutton(plot_fr, text=lbls["standard_supercharge"], variable=self.multiplier, value=4)
-        r1.bind('<Button-3>', self.show_menu)
-        Tooltip(r1, tts['standard_multiplier'])
+        r1: tk.Radiobutton | ttk.Radiobutton = radiobutton(
+            plot_fr,
+            text=lbls["standard_supercharge"],
+            variable=self.multiplier,
+            value=4,
+        )
+        r1.bind("<Button-3>", self.show_menu)
+        Tooltip(r1, tts["standard_multiplier"])
 
         r1.grid(row=row, column=col)
         col += 1
-        r2:tk.Radiobutton|ttk.Radiobutton = radiobutton(plot_fr, text=lbls["overcharge_supercharge"], variable=self.multiplier, value=6)
-        Tooltip(r2, tts['overcharge_multiplier'])
-        r2.bind('<Button-3>', self.show_menu)
+        r2: tk.Radiobutton | ttk.Radiobutton = radiobutton(
+            plot_fr,
+            text=lbls["overcharge_supercharge"],
+            variable=self.multiplier,
+            value=6,
+        )
+        Tooltip(r2, tts["overcharge_multiplier"])
+        r2.bind("<Button-3>", self.show_menu)
         r2.grid(row=row, column=col)
 
-        row += 1; col = 0
-        btn_frame:tk.Frame = frame(plot_fr)
+        row += 1
+        col = 0
+        btn_frame: tk.Frame = frame(plot_fr)
         btn_frame.grid(row=row, column=col, columnspan=3, sticky=tk.W)
 
-        r = 0; col = 0
-        self.import_route_btn:tk.Button|ttk.Button = button(btn_frame, text=btns["import_route"], command=lambda: self.import_route())
+        r = 0
+        col = 0
+        self.import_route_btn: tk.Button | ttk.Button = button(
+            btn_frame, text=btns["import_route"], command=lambda: self.import_route()
+        )
         self.import_route_btn.grid(row=r, column=col, padx=5, sticky=tk.W)
         col += 1
 
-        self.plot_route_btn:tk.Button|ttk.Button = button(btn_frame, text=btns["calculate_route"], command=lambda: self.neutron_plot())
+        self.plot_route_btn: tk.Button | ttk.Button = button(
+            btn_frame, text=btns["calculate_route"], command=lambda: self.neutron_plot()
+        )
         self.plot_route_btn.grid(row=r, column=col, padx=5, sticky=tk.W)
         col += 1
 
-        self.cancel_plot:tk.Button|ttk.Button = button(btn_frame, text=btns["cancel"], command=lambda: self.show_frame('Default'))
+        self.cancel_plot: tk.Button | ttk.Button = button(
+            btn_frame, text=btns["cancel"], command=lambda: self.show_frame("Default")
+        )
         self.cancel_plot.grid(row=r, column=col, padx=5, sticky=tk.W)
 
         return plot_fr
 
-
     @catch_exceptions
     def show_menu(self, e) -> str:
         # Create right click menu
-        shipmenu:dict = {}
+        shipmenu: dict = {}
         for id in Context.router.shiplist[:10]:
-            shipmenu[Context.router.ships[id].name] = [self.menu_callback, 'ship']
+            shipmenu[Context.router.ships[id].name] = [self.menu_callback, "ship"]
 
         if shipmenu != {}:
-            menu:tk.Menu = tk.Menu(self.neutron_fr, tearoff=0)
+            menu: tk.Menu = tk.Menu(self.neutron_fr, tearoff=0)
             for m, f in shipmenu.items():
                 menu.add_command(label=m, command=partial(*f, m))
             menu.post(e.x_root, e.y_root)
 
         return "break"
 
-
     def _progress(self) -> int:
-        """ Return progress as a percentage """
-        if Context.route.route == []: return 0
+        """Return progress as a percentage"""
+        if Context.route.route == []:
+            return 0
 
-        if Context.route.jumps_remaining() == 0: return 100
+        if Context.route.jumps_remaining() == 0:
+            return 100
 
         if Context.route.total_dist() > 0:
             return round(Context.route.perc_dist_rem())
         return round(Context.route.perc_jumps_rem())
 
-
     @catch_exceptions
     def _update_progbar(self) -> None:
-        """ Update our progress tooltips and progress bar """
+        """Update our progress tooltips and progress bar"""
         if Context.route.route == [] or not hasattr(self, "route_fr"):
             return
 
         # Create the tooltip with jumps/waypoints, distance, and speed depending on what we have
-        tt:str = tts["jump"] if Context.route.jc != None else tts["waypoints"]
-        j:str = ""; d:str = ""
+        tt: str = tts["jump"] if Context.route.jc != None else tts["waypoints"]
+        j: str = ""
+        d: str = ""
         if Context.route.jumps_remaining() > 0:
             j = str(Context.route.jumps_remaining())
         if Context.route.dist_remaining() > 0:
-            tmp:tuple = tuple([Context.route.dist_remaining(), 'float', '', ' Ly'])
+            tmp: tuple = tuple([Context.route.dist_remaining(), "float", "", " Ly"])
             d = f"({hfplus(tmp)}) "
         tt = tt.format(j=j, d=d)
 
         if Context.route.jumps_per_hour() > 0:
-            jr:tuple = tuple([Context.route.jumps_per_hour(), 'float'])
-            dr:tuple = tuple([Context.route.dist_per_hour(), 'float'])
-            if tt != "": tt += "\n"
-            tt += tts['speed'].format(j=hfplus(jr), d=hfplus(dr))
+            jr: tuple = tuple([Context.route.jumps_per_hour(), "float"])
+            dr: tuple = tuple([Context.route.dist_per_hour(), "float"])
+            if tt != "":
+                tt += "\n"
+            tt += tts["speed"].format(j=hfplus(jr), d=hfplus(dr))
 
         Tooltip(self.progbar, tt)
 
-        self.progbar.configure(length=self.frwidth-3, value=self._progress())
-
+        self.progbar.configure(length=self.frwidth - 3, value=self._progress())
 
     @catch_exceptions
     def update_waypoint(self) -> None:
-        if Context.route.route == [] or not hasattr(self, 'waypoint_btn'):
+        if Context.route.route == [] or not hasattr(self, "waypoint_btn"):
             return
 
-        self.waypoint_prev_btn.config(state=tk.DISABLED if Context.route.offset == 0 else tk.NORMAL)
-        self.waypoint_prev_tt:Tooltip = Tooltip(self.waypoint_prev_btn, Context.route.get_waypoint(-1))
-        self.waypoint_next_btn.config(state=tk.DISABLED if Context.route.offset >= len(Context.route.route) -1 else tk.NORMAL)
-        self.waypoint_next_tt:Tooltip = Tooltip(self.waypoint_next_btn, Context.route.get_waypoint(1))
+        self.waypoint_prev_btn.config(
+            state=tk.DISABLED if Context.route.offset == 0 else tk.NORMAL
+        )
+        self.waypoint_prev_tt: Tooltip = Tooltip(
+            self.waypoint_prev_btn, Context.route.get_waypoint(-1)
+        )
+        self.waypoint_next_btn.config(
+            state=(
+                tk.DISABLED
+                if Context.route.offset >= len(Context.route.route) - 1
+                else tk.NORMAL
+            )
+        )
+        self.waypoint_next_tt: Tooltip = Tooltip(
+            self.waypoint_next_btn, Context.route.get_waypoint(1)
+        )
 
         # We check if we're there rather than if there are no jumps remaining so
         # we don't show end of the road when someone steps forward/backward.
-        if Context.router.system == Context.route.destination() and Context.route.jumps_remaining() == 0:
-            self.waypoint_btn.configure(text=lbls["route_complete"], image='', compound=tk.NONE)
+        if (
+            Context.router.system == Context.route.destination()
+            and Context.route.jumps_remaining() == 0
+        ):
+            self.waypoint_btn.configure(
+                text=lbls["route_complete"], image="", compound=tk.NONE
+            )
             self._update_progbar()
             return
 
-        wp:str = Context.route.next_stop()
+        wp: str = Context.route.next_stop()
         self.ctc(wp)
         if Context.route.jumps_to_wp() != 0:
             wp += f" ({Context.route.jumps_to_wp()} {lbls['jumps'] if Context.route.jumps_to_wp() != 1 else lbls['jump']})"
         self._update_progbar()
 
-        if Context.route.fleetcarrier == True and Context.router.carrier_state == 'Jumping' and Context.route.get_waypoint(-1) == Context.router.system:
+        if (
+            Context.route.fleetcarrier == True
+            and Context.router.carrier_state == "Jumping"
+            and Context.route.get_waypoint(-1) == Context.router.system
+        ):
             wp = f"{lbls['carrier_jumping']}"
-        if Context.route.fleetcarrier == True and Context.router.carrier_state == 'Cooldown' and Context.route.get_waypoint(-1) == Context.router.system:
+        if (
+            Context.route.fleetcarrier == True
+            and Context.router.carrier_state == "Cooldown"
+            and Context.route.get_waypoint(-1) == Context.router.system
+        ):
             wp = f"{lbls['carrier_cooldown']}"
 
         # Set an icon if appropriate
-        image:tk.PhotoImage|str = ''  # Empty image
+        image: tk.PhotoImage | str = ""  # Empty image
         if Context.route.refuel() == True:
-            image=self.fuel_img
-            wp = ' ' + wp + ' '
+            image = self.fuel_img
+            wp = " " + wp + " "
         self.waypoint_btn.configure(text=wp, image=image, compound=tk.RIGHT)
 
-        message:list = ['large', "Next: " + str(wp)]
-        jumps:tuple = tuple([Context.route.total_jumps() - Context.route.jumps_remaining(), 'int', '0'])
-        tjumps:tuple = tuple([Context.route.total_jumps(), 'int'])
-        txt:str = lbls['jumps'] if Context.route.jc != None else lbls['waypoints']
-        jstr:str = f"{txt} {hfplus(jumps)}/{hfplus(tjumps)}"
+        jumps: tuple = tuple(
+            [Context.route.total_jumps() - Context.route.jumps_remaining(), "int", "0"]
+        )
+        tjumps: tuple = tuple([Context.route.total_jumps(), "int"])
+        txt: str = lbls["jumps"] if Context.route.jc != None else lbls["waypoints"]
+        jstr: str = f"{txt} {hfplus(jumps)}/{hfplus(tjumps)}"
         if Context.route.total_dist() > 0:
             jstr += f", {lbls['distance']} "
-            dist:tuple = tuple([Context.route.total_dist() - Context.route.dist_remaining(), 'float', '0', ''])
+            dist: tuple = tuple(
+                [
+                    Context.route.total_dist() - Context.route.dist_remaining(),
+                    "float",
+                    "0",
+                    "",
+                ]
+            )
             jstr += f"{hfplus(dist)}/{hfplus(Context.route.total_dist())} ly"
+        Context.overlay.title_text = f"Next: {wp}"
+        Context.overlay.body_text = jstr
 
-        message.extend(["normal", f"{jstr}"])
-        Overlay().show_message('Default', message, ttl=60)
+    def _create_route_fr(self, parent: tk.Frame) -> tk.Frame:
+        """Create the route display frame"""
 
-
-    def _create_route_fr(self, parent:tk.Frame) -> tk.Frame:
-        """ Create the route display frame """
-
-        route_fr:tk.Frame = frame(parent)
-        self.bar_fr:tk.LabelFrame = labelframe(route_fr, border=0, height=10, width=self.frwidth)
+        route_fr: tk.Frame = frame(parent)
+        self.bar_fr: tk.LabelFrame = labelframe(
+            route_fr, border=0, height=10, width=self.frwidth
+        )
         self.bar_fr.grid_rowconfigure(0, weight=1)
         self.bar_fr.grid_propagate(False)
         self.bar_fr.grid(row=0, column=0, pady=0, sticky=tk.EW)
 
-        self.progbar = ttk.Progressbar(self.bar_fr, orient=tk.HORIZONTAL, value=self._progress(), maximum=100, mode='determinate', length=self.frwidth-3)
-        self.progtt:Tooltip = Tooltip(self.progbar, text=tts["progress"])
+        self.progbar = ttk.Progressbar(
+            self.bar_fr,
+            orient=tk.HORIZONTAL,
+            value=self._progress(),
+            maximum=100,
+            mode="determinate",
+            length=self.frwidth - 3,
+        )
+        self.progtt: Tooltip = Tooltip(self.progbar, text=tts["progress"])
         self.progbar.rowconfigure(0, weight=1)
         self.progbar.grid(row=0, column=0, pady=0, ipady=0, sticky=tk.EW)
         self._update_progbar()
 
-        parent.after(5000, self._update_progbar) # We may need to wait til TK has finished loading before updating the progress bar
+        parent.after(
+            5000, self._update_progbar
+        )  # We may need to wait til TK has finished loading before updating the progress bar
 
-        fr1:tk.Frame = frame(route_fr, width=self.frwidth-10)
+        fr1: tk.Frame = frame(route_fr, width=self.frwidth - 10)
         fr1.grid_columnconfigure(0, weight=0)
         fr1.grid_columnconfigure(1, weight=1)
         fr1.grid_columnconfigure(2, weight=0)
         fr1.grid(row=1, column=0, sticky=tk.EW)
 
-        row:int = 0; col:int = 0
-        self.waypoint_prev_btn:tk.Button|ttk.Button = button(fr1, text=btns["prev"], width=3, command=lambda: self.goto_prev_waypoint())
-        self.waypoint_prev_tt:Tooltip = Tooltip(self.waypoint_prev_btn, Context.route.get_waypoint(-1))
+        row: int = 0
+        col: int = 0
+        self.waypoint_prev_btn: tk.Button | ttk.Button = button(
+            fr1, text=btns["prev"], width=3, command=lambda: self.goto_prev_waypoint()
+        )
+        self.waypoint_prev_tt: Tooltip = Tooltip(
+            self.waypoint_prev_btn, Context.route.get_waypoint(-1)
+        )
         self.waypoint_prev_btn.grid(row=row, column=col, padx=5, pady=5, sticky=tk.W)
 
         col += 1
-        self.waypoint_btn:tk.Button|ttk.Button = button(fr1, text=Context.route.next_stop(), width=40, command=lambda: self.ctc(Context.route.next_stop()))
+        self.waypoint_btn: tk.Button | ttk.Button = button(
+            fr1,
+            text=Context.route.next_stop(),
+            width=40,
+            command=lambda: self.ctc(Context.route.next_stop()),
+        )
         Tooltip(self.waypoint_btn, tts["copy_to_clipboard"])
         self.waypoint_btn.grid(row=row, column=col, padx=5, pady=5, sticky=tk.EW)
 
         col += 1
-        self.waypoint_next_btn:tk.Button|ttk.Button = button(fr1, text=btns["next"], width=3, command=lambda: self.goto_next_waypoint())
-        self.waypoint_next_tt:Tooltip = Tooltip(self.waypoint_next_btn, Context.route.get_waypoint(1))
+        self.waypoint_next_btn: tk.Button | ttk.Button = button(
+            fr1, text=btns["next"], width=3, command=lambda: self.goto_next_waypoint()
+        )
+        self.waypoint_next_tt: Tooltip = Tooltip(
+            self.waypoint_next_btn, Context.route.get_waypoint(1)
+        )
         self.waypoint_next_btn.grid(row=row, column=col, padx=5, pady=5, sticky=tk.W)
 
-        fr2:tk.Frame = frame(route_fr)
+        fr2: tk.Frame = frame(route_fr)
         fr2.grid_columnconfigure(0, weight=0)
         fr2.grid_columnconfigure(1, weight=0)
         fr2.grid(row=2, column=0, sticky=tk.W)
-        row = 0; col = 0
+        row = 0
+        col = 0
 
-        self.export_route_btn:tk.Button|ttk.Button = button(fr2, text=btns["export_route"], command=lambda: self._export_route())
+        self.export_route_btn: tk.Button | ttk.Button = button(
+            fr2, text=btns["export_route"], command=lambda: self._export_route()
+        )
         self.export_route_btn.grid(row=row, column=col, padx=5, sticky=tk.W)
 
         col += 1
-        self.show_route_btn:tk.Button|ttk.Button = button(fr2, text=btns["show_route"], command=lambda: self.window_route.show(Context.route))
+        self.show_route_btn: tk.Button | ttk.Button = button(
+            fr2,
+            text=btns["show_route"],
+            command=lambda: self.window_route.show(Context.route),
+        )
         self.show_route_btn.grid(row=row, column=col, padx=5, sticky=tk.W)
 
         col += 1
-        self.clear_route_btn:tk.Button|ttk.Button = button(fr2, text=btns["clear_route"], command=lambda: self._clear_route())
+        self.clear_route_btn: tk.Button | ttk.Button = button(
+            fr2, text=btns["clear_route"], command=lambda: self._clear_route()
+        )
         self.clear_route_btn.grid(row=row, column=col, padx=5, sticky=tk.W)
 
         return route_fr
 
-
     @catch_exceptions
-    def menu_callback(self, field:str = "src", param:str = "None") -> None:
-        """ Function called when a custom menu item is selected """
+    def menu_callback(self, field: str = "src", param: str = "None") -> None:
+        """Function called when a custom menu item is selected"""
         match field:
-            case 'src':
+            case "src":
                 self.source_ac.set_text(param, False)
                 self.gal_source_ac.set_text(param, False)
-            case 'dest':
+            case "dest":
                 self.dest_ac.set_text(param, False)
                 self.gal_dest_ac.set_text(param, False)
             case _:
                 for ship in Context.router.ships.values():
                     if ship.name == param:
-                        self.range_entry.set_text(ship.get_range(Context.router.cargo), False)
+                        self.range_entry.set_text(
+                            ship.get_range(Context.router.cargo), False
+                        )
                         self.multiplier.set(ship.supercharge_multiplier)
                         # Set ship in the galaxy form
                         return
 
-
-    def set_entry(self, which:Autocompleter|Placeholder|None, value:str) -> None:
-        """ Set an autocompleter or placeholder entry's text and style """
-        if which == None: return
+    def set_entry(self, which: Autocompleter | Placeholder | None, value: str) -> None:
+        """Set an autocompleter or placeholder entry's text and style"""
+        if which == None:
+            return
         which.delete(0, tk.END)
         which.insert(0, value)
         which.set_default_style()
 
-
-    def switch_ship(self, ship:Ship) -> None:
-        """ Update the plotter items when the ship changes """
+    def switch_ship(self, ship: Ship) -> None:
+        """Update the plotter items when the ship changes"""
 
         # Neutron plotter
         self.range_entry.set_text(str(ship.get_range(Context.router.cargo)), False)
         self.multiplier.set(ship.supercharge_multiplier)
 
-        shipmenu:dict = {}
+        shipmenu: dict = {}
         for id in Context.router.shiplist[:10]:
             if id in Context.router.ships:
-                shipmenu[Context.router.ships[id].name] = [self.menu_callback, 'ship']
+                shipmenu[Context.router.ships[id].name] = [self.menu_callback, "ship"]
         self.range_entry.set_menu(shipmenu)
 
         # Galaxy plotter
@@ -642,16 +911,18 @@ class UI():
         self.set_entry(self.cargo_entry, str(Context.router.cargo))
 
         # Ship dropdown
-        ships:list = [Context.router.ships[id].name for id in Context.router.shiplist]
+        ships: list = [Context.router.ships[id].name for id in Context.router.shiplist]
         if isinstance(self.shipdd, ttk.Combobox):
-            self.shipdd['values'] = ships
+            self.shipdd["values"] = ships
             return
 
         # TK OptionMenu sucks for updating values, so we have to do it manually
-        menu:tk.Menu = self.shipdd["menu"]
+        menu: tk.Menu = self.shipdd["menu"]
         menu.delete(0, "end")
-        [menu.add_command(label=ship, command=lambda item=ship: self.ship.set(item)) for ship in ships]
-
+        [
+            menu.add_command(label=ship, command=lambda item=ship: self.ship.set(item))
+            for ship in ships
+        ]
 
     @catch_exceptions
     def _export_route(self) -> None:
@@ -659,150 +930,187 @@ class UI():
             Debug.logger.error(f"Failed to export route")
             return
 
-        self.show_frame('Route')
-
+        self.show_frame("Route")
 
     def _clear_route(self) -> None:
-        """ Display a confirmation dialog for clearing the current route """
-        clear:bool = confirmDialog.askyesno(
-            Context.plugin_name,
-            lbls["clear_route_yesno"]
+        """Display a confirmation dialog for clearing the current route"""
+        clear: bool = confirmDialog.askyesno(
+            Context.plugin_name, lbls["clear_route_yesno"]
         )
         if clear == True:
             self.show_frame(Context.router.last_plot)
             Context.route = Route()
-
 
     @catch_exceptions
     def import_route(self) -> None:
         if Context.router == None or Context.router.import_route() == False:
             Debug.logger.error(f"Failed to load route {self.error_lbl['text']}")
             self.show_frame(Context.router.last_plot)
-            self.show_error(self.error_lbl['text'])
+            self.show_error(self.error_lbl["text"])
             return
 
-        self.show_frame('Route')
-
+        self.show_frame("Route")
 
     @catch_exceptions
     def neutron_plot(self) -> None:
-        """ Perform a neutron plotter plot """
+        """Perform a neutron plotter plot"""
         self.hide_error()
         self._show_busy_gui(True)
 
         self.source_ac.hide_list()
         self.dest_ac.hide_list()
 
-        params:dict = {}
+        params: dict = {}
 
-        params['from'] = self.source_ac.get().strip()
-        if params['from'] not in self.query_systems(params['from']):
-            self.show_frame('Neutron')
+        params["from"] = self.source_ac.get().strip()
+        if params["from"] not in self.query_systems(params["from"]):
+            self.show_frame("Neutron")
             self.source_ac.set_error_style()
             return
 
-        params['to'] = self.dest_ac.get().strip()
-        if params['to'] not in self.query_systems(params['to']):
-            self.show_frame('Neutron')
+        params["to"] = self.dest_ac.get().strip()
+        if params["to"] not in self.query_systems(params["to"]):
+            self.show_frame("Neutron")
             self.dest_ac.set_error_style()
             return
 
-        params['efficiency'] = int(self.efficiency_slider.get())
-        params['supercharge_multiplier'] = self.multiplier.get()
-        params['range'] = self.range_entry.var.get()
-        if not re.match(r"^\d+(\.\d+)?$", params['range']):
+        params["efficiency"] = int(self.efficiency_slider.get())
+        params["supercharge_multiplier"] = self.multiplier.get()
+        params["range"] = self.range_entry.var.get()
+        if not re.match(r"^\d+(\.\d+)?$", params["range"]):
             Debug.logger.info(f"Invalid range entry {params['range']}")
-            self.show_frame('Neutron')
+            self.show_frame("Neutron")
             self.range_entry.set_error_style()
             return
 
-        Context.router.plot_route('Neutron', params)
-
+        Context.router.plot_route("Neutron", params)
 
     @catch_exceptions
     def galaxy_plot(self) -> None:
-        """ Perform a galaxy plotter plot """
+        """Perform a galaxy plotter plot"""
         self.hide_error()
         self._show_busy_gui(True)
 
         self.gal_source_ac.hide_list()
         self.gal_dest_ac.hide_list()
 
-        ship_id:str = ''
+        ship_id: str = ""
         for id, ship in Context.router.ships.items():
             if ship.name == self.ship.get():
                 ship_id = id
                 break
 
-        if ship_id == '':
-            self.show_frame('Galaxy')
-            self.show_error(errs['no_ship'])
+        if ship_id == "":
+            self.show_frame("Galaxy")
+            self.show_error(errs["no_ship"])
             return
 
-        params:dict = {
-            'cargo': int(self.cargo_entry.get().strip()) if re.match(r"^\d+$", self.cargo_entry.get().strip()) else 0,
-            'max_time': int(self.time_limit.get()),
-            'algorithm': self.algorithm.get(),
-            'fuel_reserve': int(self.fuel_res.get().strip()) if re.match(r"^\d+(\.\d+)?$", self.fuel_res.get().strip()) else 0,
-            'is_supercharged': 1 if self.gallb.selection_includes(self.optionlist.index('is_supercharged')) else 0,
-            'use_supercharge': 1 if self.gallb.selection_includes(self.optionlist.index('use_supercharge')) else 0,
-            'use_injections': 1 if self.gallb.selection_includes(self.optionlist.index('use_injections')) else 0,
-            'exclude_secondary': 1 if self.gallb.selection_includes(self.optionlist.index('exclude_secondary')) else 0,
-            'refuel_every_scoopable': 1 if self.gallb.selection_includes(self.optionlist.index('refuel_every_scoopable')) else 0,
-            'fuel_power': Context.router.ships[ship_id].fuel_power,
-            'fuel_multiplier': Context.router.ships[ship_id].fuel_multiplier,
-            'optimal_mass': Context.router.ships[ship_id].optimal_mass,
-            'base_mass': Context.router.ships[ship_id].base_mass,
-            'tank_size': Context.router.ships[ship_id].tank_size,
-            'internal_tank_size': Context.router.ships[ship_id].internal_tank_size,
-            'max_fuel_per_jump': Context.router.ships[ship_id].max_fuel_per_jump,
-            'range_boost': Context.router.ships[ship_id].range_boost,
-            'ship_build': Context.router.ships[ship_id].loadout,
-            'supercharge_multiplier': Context.router.ships[ship_id].supercharge_multiplier,
-            'injection_multiplier': Context.router.ships[ship_id].injection_multiplier
-            }
+        params: dict = {
+            "cargo": (
+                int(self.cargo_entry.get().strip())
+                if re.match(r"^\d+$", self.cargo_entry.get().strip())
+                else 0
+            ),
+            "max_time": int(self.time_limit.get()),
+            "algorithm": self.algorithm.get(),
+            "fuel_reserve": (
+                int(self.fuel_res.get().strip())
+                if re.match(r"^\d+(\.\d+)?$", self.fuel_res.get().strip())
+                else 0
+            ),
+            "is_supercharged": (
+                1
+                if self.gallb.selection_includes(
+                    self.optionlist.index("is_supercharged")
+                )
+                else 0
+            ),
+            "use_supercharge": (
+                1
+                if self.gallb.selection_includes(
+                    self.optionlist.index("use_supercharge")
+                )
+                else 0
+            ),
+            "use_injections": (
+                1
+                if self.gallb.selection_includes(
+                    self.optionlist.index("use_injections")
+                )
+                else 0
+            ),
+            "exclude_secondary": (
+                1
+                if self.gallb.selection_includes(
+                    self.optionlist.index("exclude_secondary")
+                )
+                else 0
+            ),
+            "refuel_every_scoopable": (
+                1
+                if self.gallb.selection_includes(
+                    self.optionlist.index("refuel_every_scoopable")
+                )
+                else 0
+            ),
+            "fuel_power": Context.router.ships[ship_id].fuel_power,
+            "fuel_multiplier": Context.router.ships[ship_id].fuel_multiplier,
+            "optimal_mass": Context.router.ships[ship_id].optimal_mass,
+            "base_mass": Context.router.ships[ship_id].base_mass,
+            "tank_size": Context.router.ships[ship_id].tank_size,
+            "internal_tank_size": Context.router.ships[ship_id].internal_tank_size,
+            "max_fuel_per_jump": Context.router.ships[ship_id].max_fuel_per_jump,
+            "range_boost": Context.router.ships[ship_id].range_boost,
+            "ship_build": Context.router.ships[ship_id].loadout,
+            "supercharge_multiplier": Context.router.ships[
+                ship_id
+            ].supercharge_multiplier,
+            "injection_multiplier": Context.router.ships[ship_id].injection_multiplier,
+        }
 
-        params['source'] = self.gal_source_ac.get().strip()
-        if params['source'] not in self.query_systems(params['source']):
-            self.show_frame('Galaxy')
+        params["source"] = self.gal_source_ac.get().strip()
+        if params["source"] not in self.query_systems(params["source"]):
+            self.show_frame("Galaxy")
             self.gal_source_ac.set_error_style()
             return
 
-        params['destination'] = self.gal_dest_ac.get().strip()
-        if params['destination'] not in self.query_systems(params['destination']):
-            self.show_frame('Galaxy')
+        params["destination"] = self.gal_dest_ac.get().strip()
+        if params["destination"] not in self.query_systems(params["destination"]):
+            self.show_frame("Galaxy")
             self.gal_dest_ac.set_error_style()
             return
 
-        Context.router.plot_route('Galaxy', params)
+        Context.router.plot_route("Galaxy", params)
 
-
-    def show_error(self, error:str|None = None) -> None:
-        """ Set and show the error text """
-        if error == None: return
+    def show_error(self, error: str | None = None) -> None:
+        """Set and show the error text"""
+        if error == None:
+            return
         Debug.logger.error(f"Showing error {error}")
-        self.error_lbl['text'] = error
+        self.error_lbl["text"] = error
         self.error_lbl.grid(row=1, column=0, columnspan=2, padx=5, sticky=tk.W)
 
-
     def hide_error(self) -> None:
-        """ Hide the the error message """
+        """Hide the the error message"""
         self.error_lbl.grid_remove()
 
-
     @catch_exceptions
-    def _show_busy_gui(self, enable:bool) -> None:
-        """ Activate/deactivate the plot gui (show a progress icon) """
+    def _show_busy_gui(self, enable: bool) -> None:
+        """Activate/deactivate the plot gui (show a progress icon)"""
+
         def update(ind) -> None:
-            if self.busy_fr == None or self.show_spinner == False: return
+            if self.busy_fr == None or self.show_spinner == False:
+                return
             self.busyimg.configure(image=self.frames[ind], anchor=tk.CENTER)
             self.busy_fr.after(self.frameSpd, update, (ind + 1) % self.frameCnt)
 
-        self.show_spinner:bool = enable
+        self.show_spinner: bool = enable
         # Show the busy image
         if enable == True:
             self.sub_fr.grid_remove()
-            self.route_lbl['text'] = lbls["plotting"].format(s=Context.router.src, d=Context.router.dest)
+            self.route_lbl["text"] = lbls["plotting"].format(
+                s=Context.router.src, d=Context.router.dest
+            )
             self.busy_fr.grid(row=2, column=0, padx=10, pady=10, sticky=tk.NSEW)
             self.busy_fr.after(250, update, 0)
             return
@@ -810,25 +1118,23 @@ class UI():
         self.busy_fr.grid_remove()
         self.sub_fr.grid()
 
-
     def goto_next_waypoint(self) -> None:
-        """ Move to the next waypoint """
+        """Move to the next waypoint"""
         Context.route.update_route(1)
         self.update_waypoint()
 
-
     def goto_prev_waypoint(self) -> None:
-        """ Move back to the previous waypoint """
+        """Move back to the previous waypoint"""
         Context.route.update_route(-1)
         self.update_waypoint()
 
-
-    def ctc(self, text:str = '') -> None:
-        """ Copy text to the clipboard """
-        if self.parent == None: return
+    def ctc(self, text: str = "") -> None:
+        """Copy text to the clipboard"""
+        if self.parent == None:
+            return
 
         # It's here and below so we don't have to go through all the checks on non-linux systems
-        if sys.platform not in ['linux', 'linux2']:
+        if sys.platform not in ["linux", "linux2"]:
             # Use the native clipboard method
             self.parent.clipboard_clear()
             self.parent.clipboard_append(text)
@@ -836,15 +1142,17 @@ class UI():
             return
 
         # Try to use a CLI clipboard tool first
-        clipboard_cli:str|None = os.getenv("EDMC_CLIPBOARD_CLI", None)
+        clipboard_cli: str | None = os.getenv("EDMC_CLIPBOARD_CLI", None)
         if shutil.which("wl-copy"):
             clipboard_cli = "wl-copy"
         elif shutil.which("xclip"):
             clipboard_cli = "xclip -selection c"
 
         if clipboard_cli != None:
-            commands:list = clipboard_cli.split()
-            command:subprocess.Popen[bytes] = subprocess.Popen(["echo", "-n", text], stdout=subprocess.PIPE)
+            commands: list = clipboard_cli.split()
+            command: subprocess.Popen[bytes] = subprocess.Popen(
+                ["echo", "-n", text], stdout=subprocess.PIPE
+            )
             subprocess.Popen(commands, stdin=command.stdout)
             return
 
@@ -853,15 +1161,14 @@ class UI():
         self.parent.clipboard_append(text)
         self.parent.update()
 
-
     @catch_exceptions
     def check_range(self, one, two, three) -> None:
-        """ Validate the range entry """
+        """Validate the range entry"""
 
         self.range_entry.set_default_style()
 
-        value:str = self.range_entry.var.get()
-        if value == '' or value == self.range_entry.placeholder:
+        value: str = self.range_entry.var.get()
+        if value == "" or value == self.range_entry.placeholder:
             return
 
         if not re.match(r"^\d+(\.\d+)?$", value):
@@ -869,43 +1176,32 @@ class UI():
             self.range_entry.set_error_style()
         return
 
-
     @catch_exceptions
-    def query_systems(self, inp:str) -> list:
-        """ Function called by Autocompleter """
+    def query_systems(self, inp: str) -> list:
+        """Function called by Autocompleter"""
         try:
-            results:requests.Response = requests.get(SPANSH_SYSTEMS, params={'q': inp.strip()}, headers={'User-Agent': Context.plugin_useragent}, timeout=3)
+            results: requests.Response = requests.get(
+                SPANSH_SYSTEMS,
+                params={"q": inp.strip()},
+                headers={"User-Agent": Context.plugin_useragent},
+                timeout=3,
+            )
         except:
             return [inp]
         return json.loads(results.content)
 
-
     @catch_exceptions
-    def cooldown_complete(self) -> None:
-        """Show an informational messagebox indicating a carrier cooldown has completed."""
-        Debug.logger.debug(f"Cooldown complete notification triggered.")
-        self.update_waypoint()
-        if self.parent == None: return
-
-        # I don't love this. Overlay would be better.
-        title:str = f"{NAME} – {hdrs['cooldown_title']}"
-        message:str = lbls['cooldown_complete']
-        Overlay().show_message("Default", lbls['cooldown_complete'], "title")
-        PopupNotice(title + "\n" + message, 20000, self.parent)
-
-
-    @catch_exceptions
-    def prefs_frame(self, parent:tk.Frame) -> nb.Frame:
+    def prefs_frame(self, parent: tk.Frame) -> nb.Frame:
         """
         Return a TK Frame for adding to the EDMC settings dialog
         """
-        self.plugin_frame:tk.Frame = parent
-        frame:nb.Frame = nb.Frame(parent)
+        self.plugin_frame: tk.Frame = parent
+        frame: nb.Frame = nb.Frame(parent)
         # Make the second column fill available space
         frame.columnconfigure(1, weight=1)
-        Overlay().prefs_display(frame)
+        Context.overlay.prefs_display(frame)
         return frame
 
     def save_prefs(self) -> None:
-        Overlay().save_prefs()
+        Context.overlay.save_prefs()
         return

--- a/Router/ui.py
+++ b/Router/ui.py
@@ -771,6 +771,14 @@ class UI:
                 ]
             )
             jstr += f"{hfplus(dist)}/{hfplus(Context.route.total_dist())} ly"
+            next_refuel = Context.route.next_refuel()
+            if next_refuel is not None:
+                if next_refuel > 0:
+                    jstr += f", Next refuel in {next_refuel} jump"
+                    if next_refuel > 1:
+                        jstr += "s"
+                else:
+                    jstr += ", ⛽ Time to refuel."
         Context.overlay.title_text = f"Next: {wp}"
         Context.overlay.body_text = jstr
 

--- a/load.py
+++ b/load.py
@@ -14,7 +14,7 @@ from Router.context import Context
 from Router.route_manager import Router
 from Router.csv import CSV
 from Router.ui import UI
-from Router.overlay import Overlay, OverlayMode
+from Router.overlay import Overlay, OverlayView
 
 
 def plugin_start3(plugin_dir: str) -> str:
@@ -87,15 +87,15 @@ def journal_entry(
 
 def dashboard_entry(cmdr: str, is_beta: bool, entry: dict) -> None:
     if not (Context.route and bool(entry["Flags"] & edmc_data.FlagsInMainShip)):
-        Context.overlay.hide()
+        Context.overlay.view = OverlayView.hidden
         return
     match entry.get("GuiFocus"):
         case edmc_data.GuiFocusNoFocus:
-            Context.overlay.show(OverlayMode.cockpit)
+            Context.overlay.view = OverlayView.cockpit
         case edmc_data.GuiFocusGalaxyMap:
-            Context.overlay.show(OverlayMode.galaxy_map)
+            Context.overlay.view = OverlayView.galaxy_map
         case _:
-            Context.overlay.hide()
+            Context.overlay.view = OverlayView.hidden
 
 
 def plugin_prefs(parent: tk.Frame, cmdr: str, is_beta: bool) -> nb.Frame:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,6 @@ isort
 pytest
 pytest-cov
 pillow
+pre-commit
 
 -r requirements.txt

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -1,217 +1,318 @@
 import tkinter as tk
 from tkinter import ttk
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from math import floor
 from typing import Any
 from functools import reduce
 import operator
 
-from config import config # type: ignore
+from config import config  # type: ignore
 
 from utils.debug import Debug
 
 """
   Miscellaneous utility functions
 """
-def get_by_path(dic:dict[str, Any], keys:list[str], default:Any = None) -> Any:
-    """ Return an element from a nested object by item sequence. """
+
+
+def get_by_path(dic: dict[str, Any], keys: list[str], default: Any = None) -> Any:
+    """Return an element from a nested object by item sequence."""
     try:
         return reduce(operator.getitem, keys, dic) or default
     except (KeyError, IndexError, TypeError):
         return default
 
+
 """ UI helpers for dealing with EDMC dark mode """
 
-def frame(parent:tk.Widget, **kw) -> tk.Frame:
-    """ Deal with EDMC theme/color weirdness """
-    fr:tk.Frame = tk.Frame(parent, kw)
+
+def frame(parent: tk.Widget, **kw) -> tk.Frame:
+    """Deal with EDMC theme/color weirdness"""
+    fr: tk.Frame = tk.Frame(parent, kw)
     return fr
 
 
-def labelframe(parent:tk.Widget, **kw) -> tk.LabelFrame:
-    """ Deal with EDMC theme/color weirdness """
-    fr:tk.LabelFrame = tk.LabelFrame(parent, kw)
+def labelframe(parent: tk.Widget, **kw) -> tk.LabelFrame:
+    """Deal with EDMC theme/color weirdness"""
+    fr: tk.LabelFrame = tk.LabelFrame(parent, kw)
     return fr
 
 
-def button(fr:tk.Frame|tk.Toplevel, **kw) -> tk.Button|ttk.Button:
-    """ Deal with EDMC theme/color weirdness by creating tk buttons for dark mode """
-    if config.get_int('theme') == 0: return ttk.Button(fr, **kw)
-    return tk.Button(fr, padx=10,**kw)
+def button(fr: tk.Frame | tk.Toplevel, **kw) -> tk.Button | ttk.Button:
+    """Deal with EDMC theme/color weirdness by creating tk buttons for dark mode"""
+    if config.get_int("theme") == 0:
+        return ttk.Button(fr, **kw)
+    return tk.Button(fr, padx=10, **kw)
 
 
-def label(fr:tk.Frame|tk.Toplevel, **kw) -> tk.Label|ttk.Label:
-    """ Deal with EDMC theme/color weirdness by creating tk labels for dark mode """
+def label(fr: tk.Frame | tk.Toplevel, **kw) -> tk.Label | ttk.Label:
+    """Deal with EDMC theme/color weirdness by creating tk labels for dark mode"""
     return ttk.Label(fr, **kw)
 
 
-def radiobutton(fr:tk.Frame, **kw) -> tk.Radiobutton|ttk.Radiobutton:
-    """ Deal with EDMC theme/color weirdness by creating tk buttons for dark mode """
-    if config.get_int('theme') == 0: return ttk.Radiobutton(fr, **kw)
+def radiobutton(fr: tk.Frame, **kw) -> tk.Radiobutton | ttk.Radiobutton:
+    """Deal with EDMC theme/color weirdness by creating tk buttons for dark mode"""
+    if config.get_int("theme") == 0:
+        return ttk.Radiobutton(fr, **kw)
 
-    rb:tk.Radiobutton = tk.Radiobutton(fr, **kw)
-    rb.config(fg=config.get_str('dark_text'))
+    rb: tk.Radiobutton = tk.Radiobutton(fr, **kw)
+    rb.config(fg=config.get_str("dark_text"))
     return rb
 
 
-def combobox(fr:tk.Frame, v:tk.StringVar, **kw) -> ttk.Combobox|tk.OptionMenu:
-    """ Deal with EDMC theme/color weirdness by creating tk.optionmenu for dark mode """
-    if config.get_int('theme') == 0: return ttk.Combobox(fr, textvariable=v, state='readonly', **kw)
+def combobox(fr: tk.Frame, v: tk.StringVar, **kw) -> ttk.Combobox | tk.OptionMenu:
+    """Deal with EDMC theme/color weirdness by creating tk.optionmenu for dark mode"""
+    if config.get_int("theme") == 0:
+        return ttk.Combobox(fr, textvariable=v, state="readonly", **kw)
 
-    value:str = ''
-    values:list = []
-    if len(kw.get('values', [])) > 0:
-        value = kw['values'][0]
-    if len(kw.get('values', [])) > 1:
-        values = kw['values'][1:]
+    value: str = ""
+    values: list = []
+    if len(kw.get("values", [])) > 0:
+        value = kw["values"][0]
+    if len(kw.get("values", [])) > 1:
+        values = kw["values"][1:]
 
-    om:tk.OptionMenu = tk.OptionMenu(fr, v, value, *values)
-    om.configure(activeforeground=config.get_str('dark_text'), highlightbackground='black', activebackground='black', border=0, borderwidth=0, highlightthickness=0, relief=tk.FLAT)
+    om: tk.OptionMenu = tk.OptionMenu(fr, v, value, *values)
+    om.configure(
+        activeforeground=config.get_str("dark_text"),
+        highlightbackground="black",
+        activebackground="black",
+        border=0,
+        borderwidth=0,
+        highlightthickness=0,
+        relief=tk.FLAT,
+    )
     return om
 
 
-def listbox(fr:tk.Frame, items:list) -> tk.Listbox:
-    """ Deal with EDMC theme/color weirdness by creating tk listbox for dark mode """
+def listbox(fr: tk.Frame, items: list) -> tk.Listbox:
+    """Deal with EDMC theme/color weirdness by creating tk listbox for dark mode"""
     # @TODO: Switch the plain mode for a treeview?
-    rows:int = min(len(items), 10)
-    lb:tk.Listbox = tk.Listbox(fr, height=rows, selectmode=tk.MULTIPLE, exportselection=False)
-    lb.configure(border=0, borderwidth=0, activestyle=tk.NONE, relief=tk.FLAT, highlightthickness=0)
+    rows: int = min(len(items), 10)
+    lb: tk.Listbox = tk.Listbox(
+        fr, height=rows, selectmode=tk.MULTIPLE, exportselection=False
+    )
+    lb.configure(
+        border=0,
+        borderwidth=0,
+        activestyle=tk.NONE,
+        relief=tk.FLAT,
+        highlightthickness=0,
+    )
     for i in range(len(items)):
         lb.insert(tk.END, items[i])
 
-    if config.get_int('theme') == 0: return lb
+    if config.get_int("theme") == 0:
+        return lb
 
-    lb.configure(selectbackground='gray25', highlightbackground='black', background='black')
+    lb.configure(
+        selectbackground="gray25", highlightbackground="black", background="black"
+    )
     return lb
 
 
-def checkbox(fr:tk.Frame, **kw) -> ttk.Checkbutton|tk.Checkbutton:
-    """ Deal with EDMC theme/color weirdness by creating tk for dark mode """
-    if config.get_int('theme') == 0: return ttk.Checkbutton(fr, **kw)
+def checkbox(fr: tk.Frame, **kw) -> ttk.Checkbutton | tk.Checkbutton:
+    """Deal with EDMC theme/color weirdness by creating tk for dark mode"""
+    if config.get_int("theme") == 0:
+        return ttk.Checkbutton(fr, **kw)
 
-    box:tk.Checkbutton = tk.Checkbutton(fr, **kw)
+    box: tk.Checkbutton = tk.Checkbutton(fr, **kw)
     return box
 
 
-def scale(fr:tk.Frame, **kw) -> tk.Scale|ttk.Scale:
-    """ Deal with EDMC theme/color weirdness by creating tk buttons for dark mode """
+def scale(fr: tk.Frame, **kw) -> tk.Scale | ttk.Scale:
+    """Deal with EDMC theme/color weirdness by creating tk buttons for dark mode"""
     sc = tk.Scale(fr, kw, border=0, borderwidth=0, highlightthickness=0, relief=tk.FLAT)
 
-    if config.get_int('theme') == 0: return sc
+    if config.get_int("theme") == 0:
+        return sc
 
-    sc.configure(troughcolor='gray25', highlightbackground='black', activebackground='black')
+    sc.configure(
+        troughcolor="gray25", highlightbackground="black", activebackground="black"
+    )
     return sc
 
 
-def hfplus(val:int|float|str|bool|tuple, type:str|None = None) -> str:
+def hfplus(val: int | float | str | bool | tuple, type: str | None = None) -> str:
     """
-        A general customized formatting function.
-        Args:
-            val (int|float|str|bool|tuple): A tuple or a value
-            tuple can contain up to 4 elements: (value, type, default, units)
-            'int' and 'float' force types, 'num' will decide based on the value
-            'fixed' will return the value modified
-        Returns:
-            str: The human-readable friendly/readable result
+    A general customized formatting function.
+    Args:
+        val (int|float|str|bool|tuple): A tuple or a value
+        tuple can contain up to 4 elements: (value, type, default, units)
+        'int' and 'float' force types, 'num' will decide based on the value
+        'fixed' will return the value modified
+    Returns:
+        str: The human-readable friendly/readable result
     """
-    units:str = ''
-    default:str = ''
+    units: str = ""
+    default: str = ""
 
-    if isinstance(val, tuple): # Handle a tuple of 1-4 elements: (value, type, default, units)
-        if len(val) > 1: type = val[1]
-        if len(val) > 2: default = val[2]
-        if len(val) > 3: units = val[3]
-        if len(val) > 0: value = val[0]
+    if isinstance(
+        val, tuple
+    ):  # Handle a tuple of 1-4 elements: (value, type, default, units)
+        if len(val) > 1:
+            type = val[1]
+        if len(val) > 2:
+            default = val[2]
+        if len(val) > 3:
+            units = val[3]
+        if len(val) > 0:
+            value = val[0]
     else:
-        value:int|float|str|bool = val
-        if (isinstance(value, str) and re.match(value, r"^\d+-\d+-\d+ \d+\:\d+")): type = 'datetime'
-        if isinstance(value, bool): type = 'bool'
-        if isinstance(value, int) or isinstance(value, float): type = 'num'
+        value: int | float | str | bool = val
+        if isinstance(value, str) and re.match(value, r"^\d+-\d+-\d+ \d+\:\d+"):
+            type = "datetime"
+        if isinstance(value, bool):
+            type = "bool"
+        if isinstance(value, int) or isinstance(value, float):
+            type = "num"
 
     # Fixed is left entirely alone
-    if type == 'fixed': return str(value) + units
+    if type == "fixed":
+        return str(value) + units
 
     # Empty, zero or false we return the default so the display isn't full of "No" and "0" etc.
-    if value in [None, False, 'False', 'false', 'NO', 'No', 'no', 0, '0', '', ' ', 'Null', 'null']: return default
+    if value in [
+        None,
+        False,
+        "False",
+        "false",
+        "NO",
+        "No",
+        "no",
+        0,
+        "0",
+        "",
+        " ",
+        "Null",
+        "null",
+    ]:
+        return default
 
-    ret:str = ""
+    ret: str = ""
     match type:
-        case 'bool': # We're going to display Yes (blanks and False are handled above)
+        case "bool":  # We're going to display Yes (blanks and False are handled above)
             ret = "Yes"
 
-        case 'datetime': # If it's a datetime convert it from the json date format to our date format
-            ret = datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S").strftime("%Y-%m-%d %H:%M")
+        case (
+            "datetime"
+        ):  # If it's a datetime convert it from the json date format to our date format
+            ret = datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S").strftime(
+                "%Y-%m-%d %H:%M"
+            )
 
-        case 'interval': # Approximated interval (no seconds, only show minutes if it's less than a day)
-            days , rem = divmod(int(value), 60*60*24)
-            hours, rem = divmod(rem, 60*60)
+        case (
+            "interval"
+        ):  # Approximated interval (no seconds, only show minutes if it's less than a day)
+            days, rem = divmod(int(value), 60 * 60 * 24)
+            hours, rem = divmod(rem, 60 * 60)
             mins, rem = divmod(rem, 60)
-            tmp:list = []
-            if floor(days) > 1: tmp.append(f"{floor(days)} days")
-            elif int(days) > 0: tmp.append(f"1 day")
-            if floor(hours) > 1: tmp.append(f"{floor(hours)} hours")
-            elif int(hours) > 0: tmp.append(f" 1 hour")
+            tmp: list = []
+            if floor(days) > 1:
+                tmp.append(f"{floor(days)} days")
+            elif int(days) > 0:
+                tmp.append(f"1 day")
+            if floor(hours) > 1:
+                tmp.append(f"{floor(hours)} hours")
+            elif int(hours) > 0:
+                tmp.append(f" 1 hour")
             if len(tmp) < 2:
-                if floor(mins) > 1: tmp.append(f" {int(mins)} minutes")
-                elif mins > 0: tmp.append(f" 1 minute")
-            ret = ' '.join(tmp)
+                if floor(mins) > 1:
+                    tmp.append(f" {int(mins)} minutes")
+                elif mins > 0:
+                    tmp.append(f" 1 minute")
+            ret = " ".join(tmp)
 
-        case 'num' | 'float' | 'int': # We only shorten/simplify numbers over 100k. Smaller ones we just display with commas at thousands
+        case (
+            "num" | "float" | "int"
+        ):  # We only shorten/simplify numbers over 100k. Smaller ones we just display with commas at thousands
             if float(value) > 10000:
-                abbrs:list[str] = ['', 'K', 'M', 'B', 'T']  # Abbreviations for thousands, millions, billions, trillions
-                fnum:float = float('{:.3g}'.format(value))
+                abbrs: list[str] = [
+                    "",
+                    "K",
+                    "M",
+                    "B",
+                    "T",
+                ]  # Abbreviations for thousands, millions, billions, trillions
+                fnum: float = float("{:.3g}".format(value))
                 magnitude = 0
                 while abs(fnum) >= 1000:
-                    if magnitude >= len(abbrs) - 1: break
+                    if magnitude >= len(abbrs) - 1:
+                        break
                     magnitude += 1
                     fnum /= 1000.0
-                ret = '{}{}'.format('{:f}'.format(fnum).rstrip('0').rstrip('.'), abbrs[magnitude])
-            elif float(value) > 100 or type == 'int': # No decimals above 100
+                ret = "{}{}".format(
+                    "{:f}".format(fnum).rstrip("0").rstrip("."), abbrs[magnitude]
+                )
+            elif float(value) > 100 or type == "int":  # No decimals above 100
                 ret = f"{value:,.0f}"
-            elif float(value) > 10: # Only 1 above 10
+            elif float(value) > 10:  # Only 1 above 10
                 ret = f"{value:,.1f}"
-            elif type == 'float': # Two if it's <10 and a float.
+            elif type == "float":  # Two if it's <10 and a float.
                 ret = f"{value:,.2f}"
             else:
                 ret = f"{value:,}"
 
-        case _: # Title case two words, leave longer strings as is
-            ret = str(value).title() if str(value).count(' ') < 2 and re.search(r"[A-Z0-9]", str(value)) == None else str(value)
+        case _:  # Title case two words, leave longer strings as is
+            ret = (
+                str(value).title()
+                if str(value).count(" ") < 2
+                and re.search(r"[A-Z0-9]", str(value)) == None
+                else str(value)
+            )
 
     return ret + units
 
+
+def timedelta_str(value: timedelta):
+    hours, rem = divmod(value.seconds, 3600)
+    minutes, seconds = divmod(rem, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
 class PopupNotice:
-    """ Create a temporary popup window """
-    def __init__(self, notice:str = '', timeout:int = 0, config = None) -> None:
+    """Create a temporary popup window"""
+
+    def __init__(self, notice: str = "", timeout: int = 0, config=None) -> None:
         self.config = config
         self.root = tk.Tk()
         self.root.overrideredirect(True)
         self.root.attributes("-alpha", 0.6)
-        self.root.geometry(config.window_geometries.get('Alert', "300x150-1+0"))
+        self.root.geometry(config.window_geometries.get("Alert", "300x150-1+0"))
         self.root.attributes("-topmost", True)
-        self.frame = tk.Frame(self.root, bg='red4', relief="raised")
+        self.frame = tk.Frame(self.root, bg="red4", relief="raised")
         self.frame.pack(fill="both", expand=True)
-        label = tk.Label(self.frame, text=notice, fg="white", bg="red4", font=("Helvetica", 12, "bold"), justify=tk.CENTER)
+        label = tk.Label(
+            self.frame,
+            text=notice,
+            fg="white",
+            bg="red4",
+            font=("Helvetica", 12, "bold"),
+            justify=tk.CENTER,
+        )
         label.pack(pady=20, anchor=tk.CENTER)
-        exit_btn = tk.Button(self.frame, text="Close", fg="white", bg="red4", command=self.close)
+        exit_btn = tk.Button(
+            self.frame, text="Close", fg="white", bg="red4", command=self.close
+        )
         exit_btn.pack(pady=10)
-        if timeout > 0: self.root.after(timeout, self.close)
+        if timeout > 0:
+            self.root.after(timeout, self.close)
         self.frame.bind("<Button-1>", self.start_move)
         self.frame.bind("<B1-Motion>", self.do_move)
 
     def start_move(self, event) -> None:
-        self.x:int = event.x
-        self.y:int = event.y
+        self.x: int = event.x
+        self.y: int = event.y
 
     def do_move(self, event) -> None:
-        deltax:int = event.x - self.x
-        deltay:int = event.y - self.y
-        x:int = self.root.winfo_x() + deltax
-        y:int = self.root.winfo_y() + deltay
+        deltax: int = event.x - self.x
+        deltay: int = event.y - self.y
+        x: int = self.root.winfo_x() + deltax
+        y: int = self.root.winfo_y() + deltay
         self.root.geometry(f"+{x}+{y}")
 
     def close(self) -> None:
         if self.root and self.root.winfo_exists():
-            self.config.window_geometries['Alert'] = self.root.winfo_geometry()
+            self.config.window_geometries["Alert"] = self.root.winfo_geometry()
             self.root.destroy()


### PR DESCRIPTION
Hey hey! Opening this as a draft for feedback and since this isn't really in a polished state at the moment.

The massive amount of changes are due to my editor applying [black](https://github.com/psf/black) formatting automatically on save on the files I touch, I can disable that if needed and rework the changes to only what's being modified without formatting. That being said, I would strongly recommend black or some other auto-formatter fired off by pre-commit since it would make contributing much easier (I'd be happy to send a PR your way to set that up).

This changes how the overlay works by adding two attributes, `title_text` and `body_text`, that automatically trigger a redraw when they're modified, making it easier to work with in the classes that publish content to the overlay. The messages these produce are sent to the overlay without a ttl, making them persistent until changed. This also adds a concept of view modes to the overlay so it can move the offset around depending on the screen that's pulled up, so it keeps it out of the way if you pull up the galaxy map, for example.
There are three view modes currently:

- hidden - This hides the overlay.
- cockpit - This uses offsets appropriate for within the cockpit.
- galaxy_map - This uses offset that by default puts the message above the search bar in the galaxy map.

It will only display the overlay if in the cockpit without a focus (normal flying) or in the galaxy map. As part of this, I removed the `x` and `y` config options and replaced them with a cockpit offset and a galaxy map offset.

I also added a message to the overlay to indicate how many jumps to the next fuel stop (if that's available in the route) and if you should refuel at the current system.

I reworked how the carrier cooldown and jump countdown calculation is handled, using the timestamp from the journal entry. This gets fed into a thread that tracks the jump countdown/cooldown and displays the time left at 1 second intervals in the overlay. I'm not entirely happy with how this works at the moment, I would prefer that the `Router` class not be in the business of updating UI elements. I'm thinking of reworking it to a callback system so the `UI` class can subscribe to updates from the `Router` class instead of the router class having to push updates to the UI. The benefit would be that the logic of the Router class would be self-contained and not have an external dependency on the UI, making it easier to test.

As a side note, I removed the call to create the popup that the carrier cooldown is complete. On my system at least it just spawned a blank square in the top left of my screen that I could not close without a restart of EDMC. Not sure if that's a me problem (I'm running this on gentoo linux through flatpak, things breaking randomly is par for the course lol) or if that's a bug other's were experiencing. I'd ideally like to add a UI element to show the carrier countdown instead of the popup.

Feedback is appreciated!